### PR TITLE
Fix tasks.json definition for Cursor

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
   // for the documentation about the extensions.json format
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "connor4312.esbuild-problem-matchers",
     "ms-vscode.extension-test-runner",
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,7 +21,60 @@
             "type": "npm",
             "script": "watch:esbuild",
             "group": "build",
-            "problemMatcher": "$esbuild-watch",
+            // ESBuild ProblemMatcher configuration, copied from https://github.com/connor4312/esbuild-problem-matchers/blob/v0.0.3/package.json
+            // The easiest way would be to use this extension: https://marketplace.visualstudio.com/items?itemName=connor4312.esbuild-problem-matchers
+            // and set `"problemMatcher": "$esbuild-watch",`
+            // but that extension isn't on the OpenVSX Marketplace, so Cursor
+            // can't find/install it automatically.
+            "problemMatcher": [
+                {
+                    "severity": "error",
+                    "applyTo": "closedDocuments",
+                    "source": "esbuild",
+                    "fileLocation": "relative",
+                    "pattern": [
+                        {
+                            "regexp": "^[✘▲] \\[([A-Z]+)\\] (.+)",
+                            "severity": 1,
+                            "message": 2
+                        },
+                        {
+                            "regexp": "^(?:\\t| {4})(?!\\s)([^:]+)(?::([0-9]+))?(?::([0-9]+))?:$",
+                            "file": 1,
+                            "line": 2,
+                            "column": 3
+                        }
+                    ]
+                },
+                {
+                    "severity": "error",
+                    "applyTo": "closedDocuments",
+                    "source": "esbuild",
+                    "fileLocation": "relative",
+                    "pattern": [
+                        {
+                            "regexp": "^[✘▲] \\[([A-Z]+)\\] (.+)",
+                            "severity": 1,
+                            "message": 2
+                        },
+                        {
+                            "regexp": "^(?:\\t| {4})(?!\\s)([^:]+)(?::([0-9]+))?(?::([0-9]+))?:$",
+                            "file": 1,
+                            "line": 2,
+                            "column": 3
+                        }
+                    ],
+                    "background": {
+                        "activeOnStart": true,
+                        "beginsPattern": {
+                            "regexp": "\\[watch\\] build started"
+                        },
+                        "endsPattern": {
+                            "regexp": "\\[watch\\] build finished"
+                        }
+                    }
+                }
+            ],
             "isBackground": true,
             "label": "npm: watch:esbuild",
             "presentation": {

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "package": "yarn run check-types && node esbuild.js --production",
     "check-types": "tsc --noEmit",
     "lint": "eslint src",
-    "pretest": "yarn runcompile",
+    "pretest": "yarn run compile",
     "test": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. --extensionTestsPath=dist/web/test/suite/extensionTests.js",
     "run-in-browser": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. ."
   },

--- a/package.json
+++ b/package.json
@@ -167,15 +167,15 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "npm run package",
-    "compile": "npm run check-types && node esbuild.js",
+    "vscode:prepublish": "yarn run package",
+    "compile": "yarn run check-types && node esbuild.js",
     "watch": "npm-run-all -p watch:*",
     "watch:esbuild": "node esbuild.js --watch",
     "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
-    "package": "npm run check-types && node esbuild.js --production",
+    "package": "yarn run check-types && node esbuild.js --production",
     "check-types": "tsc --noEmit",
     "lint": "eslint src",
-    "pretest": "npm run compile",
+    "pretest": "yarn runcompile",
     "test": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. --extensionTestsPath=dist/web/test/suite/extensionTests.js",
     "run-in-browser": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. ."
   },


### PR DESCRIPTION
We were relying on the extension connor4312.esbuild-problem-matchers, but its not in the OpenVSX marketplace, so cursor couldnt install it. This meant that when building/developing the extension with cursor it wouldnt startup automatically because it didnt detect the `[watch] build finished` output. Now it does

also updated some package.json commands to use yarn as that is our package manager.