### PR TITLE
fix: Fix the default `created_at` value when creating a flag.

### DIFF
--- a/src/providers/commandProvider.ts
+++ b/src/providers/commandProvider.ts
@@ -34,11 +34,11 @@ export default class CommandProvider {
 
     snippet
       .appendText('  feature.organizations:').appendPlaceholder('my-new-flag').appendText(':\n')
-      .appendText('    created_at: ').appendVariable('CURRENT_YEAR', '').appendText('-').appendVariable('CURRENT_MONTH', '').appendText('-').appendVariable('CURRENT_DATE', '').appendText('\n')
+      .appendText('    created_at: "').appendVariable('CURRENT_YEAR', '').appendText('-').appendVariable('CURRENT_MONTH', '').appendText('-').appendVariable('CURRENT_DATE', '').appendText('"\n')
       .appendText('    enabled: ').appendChoice(['true', 'false']).appendText('\n')
       .appendText('    owner:\n')
+      .appendText('      team: ').appendPlaceholder('REQUIRED').appendText('\n')
       .appendText('      email: ').appendPlaceholder('yourname@sentry.io').appendText('\n')
-      .appendText('      team: ').appendPlaceholder('unknown').appendText('\n')
       .appendText('    segments: []\n');
 
     textEditor.insertSnippet(snippet, target, {


### PR DESCRIPTION
It should be a string!

And `team:` is required, so lets make that more obvious so people (like me) dont assume `unknown` is good enough.