### PR TITLE
fix: Fix a case where if you run flagpole-explorer.show-evaluate-view from the command popup it fails

### DIFF
--- a/src/providers/commandProvider.ts
+++ b/src/providers/commandProvider.ts
@@ -117,11 +117,11 @@ export default class CommandProvider {
   };
 
   public showEvaluateView = (
-    feature: LogicalFeature,
+    feature?: LogicalFeature,
   ) => {
     EvaluateView.createOrShow(
       this.context.extensionUri,
-      logicalFeatureToFeature(feature),
+      feature ? logicalFeatureToFeature(feature) : null,
     );
   };
 

--- a/src/view/evaluateView.ts
+++ b/src/view/evaluateView.ts
@@ -6,7 +6,7 @@ export default class EvaluateView {
 
   public static currentPanel: EvaluateView | undefined;
 
-  public static createOrShow(extensionUri: vscode.Uri, feature: Feature) {
+  public static createOrShow(extensionUri: vscode.Uri, feature: null | Feature) {
     const column = vscode.ViewColumn.Beside;
 
     // If we already have a panel, show it.
@@ -71,8 +71,10 @@ export default class EvaluateView {
     this._panel.webview.html = this._getHtmlForWebview(webview);
   }
 
-  public selectFlag(feature: Feature) {
-    this._panel.webview.postMessage({ command: 'select-flag', feature });
+  public selectFlag(feature: null | Feature) {
+    if (feature) {
+      this._panel.webview.postMessage({ command: 'select-flag', feature });
+    }
   }
 
   public dispose() {


### PR DESCRIPTION
Fixes VSCODE-FLAGPOLE-EXPLORER-4