### PR TITLE
fix(transformer): correctly detect partial rollout when no conditions present

### DIFF
--- a/src/transform/transformers.ts
+++ b/src/transform/transformers.ts
@@ -118,9 +118,11 @@ export function symbolToLogicalSegment(uri: vscode.Uri, symbol: vscode.DocumentS
     if (rollout?.detail === '0') {
       return '0%';
     }
-    // If `rollout` is not specified it's defaulted to 100
-    // Or if there are no conditions, it's also out to 100
-    if ([undefined, '100'].includes(rollout?.detail) && conditions?.length === 0) {
+    // Rollout not specified defaults to 100; explicit 100 with no conditions = fully rolled out
+    // Distinguish between "key missing" (rollout === undefined) and "key present but non-100 detail"
+    // to avoid a partial rollout with no conditions being misread as 100%.
+    const isFullRollout = rollout === undefined || rollout.detail === '100';
+    if (isFullRollout && conditions.length === 0) {
       return '100%';
     }
     return 'partial' as const;


### PR DESCRIPTION
Previously, `[undefined, '100'].includes(rollout?.detail)` would match
`undefined` both when the rollout key is absent (correctly defaults to 100%)
and when the rollout key is present but `detail` is unpopulated by the
language server (incorrectly treated as 100%). This caused segments with
a partial rollout and no conditions to be reported as fully rolled out.

Now we explicitly check `rollout === undefined` (key absent → default 100%)
vs `rollout.detail === '100'` (explicit 100%), so a present-but-unreadable
or non-100 rollout value correctly falls through to 'partial'.