### PR TITLE
test: add unit tests co-located with source files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      node-version: 22.x
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Setup Node v${{ env.node-version }}
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
+        with:
+          node-version: ${{ env.node-version }}
+          cache: "yarn"
+
+      - run: yarn install --frozen-lockfile
+
+      - run: yarn run lint
+
+      - run: yarn run check-types
+
+  test:
+    runs-on: ubuntu-latest
+    env:
+      node-version: 22.x
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Setup Node v${{ env.node-version }}
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
+        with:
+          node-version: ${{ env.node-version }}
+          cache: "yarn"
+
+      - run: yarn install --frozen-lockfile
+
+      - name: Run tests
+        uses: GabrielBB/xvfb-action@b706e4e27b14669b486812790492dc50ca16b465 # v1.7
+        with:
+          run: yarn run test

--- a/esbuild.js
+++ b/esbuild.js
@@ -9,8 +9,7 @@ const production = process.argv.includes('--production');
 const watch = process.argv.includes('--watch');
 
 async function main() {
-  const ctx = await esbuild.context({
-    entryPoints: ['src/extension.ts'],
+  const sharedOptions = {
     bundle: true,
     format: 'cjs',
     minify: production,
@@ -18,8 +17,13 @@ async function main() {
     sourcesContent: false,
     platform: 'node',
     outdir: 'dist/',
-    external: ['vscode'],
     logLevel: 'warning',
+  };
+
+  const extensionCtx = await esbuild.context({
+    ...sharedOptions,
+    entryPoints: ['src/extension.ts'],
+    external: ['vscode'],
     plugins: [
       copyStaticFiles({
 				src: './static',
@@ -44,15 +48,26 @@ async function main() {
           ],
         },
       }),
-      testBundlePlugin,
-      esbuildProblemMatcherPlugin /* add to the end of plugins array */
+      esbuildProblemMatcherPlugin,
     ]
   });
+
+  const testCtx = await esbuild.context({
+    ...sharedOptions,
+    entryPoints: ['src/web/test/suite/extensionTests.ts'],
+    outbase: 'src',
+    external: ['vscode'],
+    plugins: [
+      testBundlePlugin,
+      esbuildProblemMatcherPlugin,
+    ]
+  });
+
   if (watch) {
-    await ctx.watch();
+    await Promise.all([extensionCtx.watch(), testCtx.watch()]);
   } else {
-    await ctx.rebuild();
-    await ctx.dispose();
+    await Promise.all([extensionCtx.rebuild(), testCtx.rebuild()]);
+    await Promise.all([extensionCtx.dispose(), testCtx.dispose()]);
   }
 }
 
@@ -71,14 +86,14 @@ const testBundlePlugin = {
       }
     });
     build.onLoad({ filter: /[\/\\]extensionTests\.ts$/ }, async args => {
-      const testsRoot = path.join(__dirname, 'src/test');
-      const files = await glob.glob('*.test.{ts,tsx}', { cwd: testsRoot, posix: true });
+      const srcRoot = path.join(__dirname, 'src');
+      const files = await glob.glob('**/*.test.{ts,tsx}', { cwd: srcRoot, posix: true, ignore: ['node_modules/**'] });
       return {
         contents:
           `export { run } from './mochaTestRunner.ts';` +
-          files.map(f => `import('./${f}');`).join(''),
-        watchDirs: files.map(f => path.dirname(path.resolve(testsRoot, f))),
-        watchFiles: files.map(f => path.resolve(testsRoot, f))
+          files.map(f => `import '../../../${f}';`).join(''),
+        watchDirs: files.map(f => path.dirname(path.resolve(srcRoot, f))),
+        watchFiles: files.map(f => path.resolve(srcRoot, f))
       };
     });
   }

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "feature flag"
   ],
   "pricing": "Free",
-
   "activationEvents": [
     "workspaceContains:**/flagpole.yaml"
   ],
   "main": "./dist/extension.js",
+  "browser": "./dist/extension.js",
   "contributes": {
     "configurationDefaults": {
       "files.associations": {
@@ -204,6 +204,7 @@
     "@typescript-eslint/parser": "8.31.1",
     "@vscode/test-cli": "0.0.11",
     "@vscode/test-electron": "2.5.2",
+    "@vscode/test-web": "^0.0.80",
     "assert": "2.1.0",
     "esbuild": "0.25.3",
     "esbuild-copy-static-files": "0.1.0",

--- a/src/stores/outlineStore.test.ts
+++ b/src/stores/outlineStore.test.ts
@@ -1,0 +1,237 @@
+import * as assert from '../test-utils/assert';
+import * as vscode from 'vscode';
+import OutlineStore from './outlineStore';
+
+function makeSymbol(name: string, detail: string, children: vscode.DocumentSymbol[] = []): vscode.DocumentSymbol {
+  const range = new vscode.Range(0, 0, 0, 0);
+  const sym = new vscode.DocumentSymbol(name, detail, vscode.SymbolKind.Property, range, range);
+  sym.children = children;
+  return sym;
+}
+
+const uri = vscode.Uri.parse('file:///test/flagpole.yaml');
+
+class TestableOutlineStore extends OutlineStore {
+  public static testDocumentSymbolsToMap(uri: vscode.Uri, symbols: vscode.DocumentSymbol[]) {
+    return OutlineStore.documentSymbolsToMap(uri, symbols);
+  }
+}
+
+suite('OutlineStore.documentSymbolsToMap', () => {
+  test('returns undefined when no options symbol exists', () => {
+    const symbols = [makeSymbol('not-options', '')];
+    const result = TestableOutlineStore.testDocumentSymbolsToMap(uri, symbols);
+    assert.strictEqual(result, undefined);
+  });
+
+  test('returns undefined for empty symbols array', () => {
+    const result = TestableOutlineStore.testDocumentSymbolsToMap(uri, []);
+    assert.strictEqual(result, undefined);
+  });
+
+  test('returns empty collections when options has no children', () => {
+    const options = makeSymbol('options', '');
+    const result = TestableOutlineStore.testDocumentSymbolsToMap(uri, [options]);
+    assert.ok(result);
+    assert.strictEqual(result.allFeatures.length, 0);
+    assert.strictEqual(result.allSegments.length, 0);
+    assert.strictEqual(result.allConditions.length, 0);
+    assert.deepStrictEqual(result.allOwners, {});
+    assert.deepStrictEqual(result.allRollouts, {});
+    assert.deepStrictEqual(result.allEnabled, {});
+    assert.deepStrictEqual(result.allCreatedAt, {});
+  });
+
+  test('parses a single feature into all collections', () => {
+    const options = makeSymbol('options', '', [
+      makeSymbol('feature.organizations:my-flag', '', [
+        makeSymbol('created_at', '2025-01-15'),
+        makeSymbol('enabled', 'true'),
+        makeSymbol('owner', 'team-alpha'),
+        makeSymbol('segments', '', [
+          makeSymbol('0', '', [
+            makeSymbol('name', 'GA'),
+            makeSymbol('rollout', '100'),
+            makeSymbol('conditions', '', []),
+          ]),
+        ]),
+      ]),
+    ]);
+
+    const result = TestableOutlineStore.testDocumentSymbolsToMap(uri, [options]);
+    assert.ok(result);
+    assert.strictEqual(result.allFeatures.length, 1);
+    assert.strictEqual(result.allFeatures[0].name, 'feature.organizations:my-flag');
+    assert.strictEqual(result.allSegments.length, 1);
+    assert.strictEqual(result.allConditions.length, 0);
+    assert.ok('team-alpha' in result.allOwners);
+    assert.ok('100%' in result.allRollouts);
+    assert.ok('true' in result.allEnabled);
+    assert.ok('2025-01-15' in result.allCreatedAt);
+  });
+
+  test('groups features by owner', () => {
+    const options = makeSymbol('options', '', [
+      makeSymbol('flag-a', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('owner', 'team-alpha'),
+      ]),
+      makeSymbol('flag-b', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('owner', 'team-alpha'),
+      ]),
+      makeSymbol('flag-c', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('owner', 'team-beta'),
+      ]),
+    ]);
+
+    const result = TestableOutlineStore.testDocumentSymbolsToMap(uri, [options]);
+    assert.ok(result);
+    assert.strictEqual(Object.keys(result.allOwners).length, 2);
+    assert.strictEqual(result.allOwners['team-alpha'].children.length, 2);
+    assert.strictEqual(result.allOwners['team-beta'].children.length, 1);
+  });
+
+  test('groups features by rollout state', () => {
+    const options = makeSymbol('options', '', [
+      makeSymbol('flag-full', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('owner', 'team-x'),
+        makeSymbol('segments', '', [
+          makeSymbol('0', '', [
+            makeSymbol('name', 'GA'),
+            makeSymbol('rollout', '100'),
+            makeSymbol('conditions', '', []),
+          ]),
+        ]),
+      ]),
+      makeSymbol('flag-partial', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('owner', 'team-x'),
+        makeSymbol('segments', '', [
+          makeSymbol('0', '', [
+            makeSymbol('name', 'LA'),
+            makeSymbol('rollout', '100'),
+            makeSymbol('conditions', '', [
+              makeSymbol('0', '', [
+                makeSymbol('operator', 'in'),
+                makeSymbol('property', 'organization_slug'),
+                makeSymbol('value', 'sentry'),
+              ]),
+            ]),
+          ]),
+        ]),
+      ]),
+      makeSymbol('flag-zero', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('owner', 'team-x'),
+      ]),
+    ]);
+
+    const result = TestableOutlineStore.testDocumentSymbolsToMap(uri, [options]);
+    assert.ok(result);
+    assert.ok('100%' in result.allRollouts);
+    assert.ok('partial' in result.allRollouts);
+    assert.ok('0%' in result.allRollouts);
+    assert.strictEqual(result.allRollouts['100%'].children.length, 1);
+    assert.strictEqual(result.allRollouts['partial'].children.length, 1);
+    assert.strictEqual(result.allRollouts['0%'].children.length, 1);
+  });
+
+  test('groups features by enabled state', () => {
+    const options = makeSymbol('options', '', [
+      makeSymbol('flag-enabled', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('enabled', 'true'),
+        makeSymbol('owner', 'team-x'),
+      ]),
+      makeSymbol('flag-disabled', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('enabled', 'false'),
+        makeSymbol('owner', 'team-x'),
+      ]),
+    ]);
+
+    const result = TestableOutlineStore.testDocumentSymbolsToMap(uri, [options]);
+    assert.ok(result);
+    assert.ok('true' in result.allEnabled);
+    assert.ok('false' in result.allEnabled);
+    assert.strictEqual(result.allEnabled['true'].children.length, 1);
+    assert.strictEqual(result.allEnabled['false'].children.length, 1);
+  });
+
+  test('groups features by created_at', () => {
+    const options = makeSymbol('options', '', [
+      makeSymbol('flag-a', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('owner', 'team-x'),
+      ]),
+      makeSymbol('flag-b', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('owner', 'team-x'),
+      ]),
+      makeSymbol('flag-c', '', [
+        makeSymbol('created_at', '2026-06-01'),
+        makeSymbol('owner', 'team-x'),
+      ]),
+    ]);
+
+    const result = TestableOutlineStore.testDocumentSymbolsToMap(uri, [options]);
+    assert.ok(result);
+    assert.strictEqual(Object.keys(result.allCreatedAt).length, 2);
+    assert.strictEqual(result.allCreatedAt['2025-01-01'].children.length, 2);
+    assert.strictEqual(result.allCreatedAt['2026-06-01'].children.length, 1);
+  });
+
+  test('collects all segments and conditions', () => {
+    const options = makeSymbol('options', '', [
+      makeSymbol('flag-a', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('owner', 'team-x'),
+        makeSymbol('segments', '', [
+          makeSymbol('0', '', [
+            makeSymbol('name', 'LA'),
+            makeSymbol('rollout', '100'),
+            makeSymbol('conditions', '', [
+              makeSymbol('0', '', [
+                makeSymbol('operator', 'in'),
+                makeSymbol('property', 'organization_slug'),
+                makeSymbol('value', 'sentry'),
+              ]),
+              makeSymbol('1', '', [
+                makeSymbol('operator', 'equals'),
+                makeSymbol('property', 'user_is-staff'),
+                makeSymbol('value', 'true'),
+              ]),
+            ]),
+          ]),
+          makeSymbol('1', '', [
+            makeSymbol('name', 'GA'),
+            makeSymbol('rollout', '100'),
+            makeSymbol('conditions', '', []),
+          ]),
+        ]),
+      ]),
+    ]);
+
+    const result = TestableOutlineStore.testDocumentSymbolsToMap(uri, [options]);
+    assert.ok(result);
+    assert.strictEqual(result.allSegments.length, 2);
+    assert.strictEqual(result.allConditions.length, 2);
+    assert.strictEqual(result.allConditions[0].property, 'organization_slug');
+    assert.strictEqual(result.allConditions[1].property, 'user_is-staff');
+  });
+
+  test('preserves range and selectionRange from options symbol', () => {
+    const range = new vscode.Range(10, 0, 100, 0);
+    const selRange = new vscode.Range(10, 2, 10, 9);
+    const options = new vscode.DocumentSymbol('options', '', vscode.SymbolKind.Property, range, selRange);
+    options.children = [];
+
+    const result = TestableOutlineStore.testDocumentSymbolsToMap(uri, [options]);
+    assert.ok(result);
+    assert.ok(result.range.isEqual(range));
+    assert.ok(result.selectionRange.isEqual(selRange));
+  });
+});

--- a/src/stores/selectedElementsStore.test.ts
+++ b/src/stores/selectedElementsStore.test.ts
@@ -1,0 +1,146 @@
+import * as assert from '../test-utils/assert';
+import * as vscode from 'vscode';
+import SelectedElementsStore from './selectedElementsStore';
+import { LogicalFeature, LogicalSegment, LogicalCondition } from '../transform/transformers';
+
+function makeRange(startLine: number, startChar: number, endLine: number, endChar: number): vscode.Range {
+  return new vscode.Range(startLine, startChar, endLine, endChar);
+}
+
+function makeSelection(startLine: number, startChar: number, endLine: number, endChar: number): vscode.Selection {
+  return new vscode.Selection(startLine, startChar, endLine, endChar);
+}
+
+function makeSymbol(name: string, range: vscode.Range): vscode.DocumentSymbol {
+  return new vscode.DocumentSymbol(name, '', vscode.SymbolKind.Property, range, range);
+}
+
+const uri = vscode.Uri.parse('file:///test/flagpole.yaml');
+
+function makeFeature(name: string, range: vscode.Range): LogicalFeature {
+  return {
+    symbol: makeSymbol(name, range),
+    uri,
+    name,
+    created_at: '2025-01-01',
+    enabled: true,
+    owner: 'team-x',
+    segmentsSymbol: undefined,
+    segments: [],
+    rolloutState: '0%',
+    hasExtraSegments: false,
+  };
+}
+
+function makeSegment(name: string, range: vscode.Range): LogicalSegment {
+  return {
+    symbol: makeSymbol(name, range),
+    uri,
+    name,
+    rollout: 100,
+    conditionsSymbol: undefined,
+    conditions: [],
+    rolloutState: '100%',
+  };
+}
+
+function makeCondition(property: string, range: vscode.Range): LogicalCondition {
+  const parentSymbol = makeSymbol('conditions', range);
+  return {
+    symbol: makeSymbol(property, range),
+    parent: parentSymbol,
+    uri,
+    property,
+    operator: 'in',
+    value: 'sentry',
+  };
+}
+
+suite('SelectedElementsStore.filterSelectedElements', () => {
+  test('returns empty array when selections is undefined', () => {
+    const features = [makeFeature('flag-a', makeRange(0, 0, 5, 0))];
+    const result = SelectedElementsStore.filterSelectedElements(undefined, features);
+    assert.deepStrictEqual(result, []);
+  });
+
+  test('returns empty array when selections is empty', () => {
+    const features = [makeFeature('flag-a', makeRange(0, 0, 5, 0))];
+    const result = SelectedElementsStore.filterSelectedElements([], features);
+    assert.deepStrictEqual(result, []);
+  });
+
+  test('returns empty array when elements is empty', () => {
+    const selections = [makeSelection(0, 0, 5, 0)];
+    const result = SelectedElementsStore.filterSelectedElements(selections, []);
+    assert.deepStrictEqual(result, []);
+  });
+
+  test('returns features that intersect with selection', () => {
+    const featureA = makeFeature('flag-a', makeRange(0, 0, 5, 0));
+    const featureB = makeFeature('flag-b', makeRange(10, 0, 15, 0));
+    const featureC = makeFeature('flag-c', makeRange(20, 0, 25, 0));
+
+    const selections = [makeSelection(3, 0, 3, 0)];
+    const result = SelectedElementsStore.filterSelectedElements(selections, [featureA, featureB, featureC]);
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].name, 'flag-a');
+  });
+
+  test('returns multiple features when selection spans them', () => {
+    const featureA = makeFeature('flag-a', makeRange(0, 0, 5, 0));
+    const featureB = makeFeature('flag-b', makeRange(5, 0, 10, 0));
+
+    const selections = [makeSelection(0, 0, 10, 0)];
+    const result = SelectedElementsStore.filterSelectedElements(selections, [featureA, featureB]);
+    assert.strictEqual(result.length, 2);
+  });
+
+  test('handles multiple selections', () => {
+    const featureA = makeFeature('flag-a', makeRange(0, 0, 5, 0));
+    const featureB = makeFeature('flag-b', makeRange(10, 0, 15, 0));
+    const featureC = makeFeature('flag-c', makeRange(20, 0, 25, 0));
+
+    const selections = [
+      makeSelection(2, 0, 2, 0),
+      makeSelection(22, 0, 22, 0),
+    ];
+    const result = SelectedElementsStore.filterSelectedElements(selections, [featureA, featureB, featureC]);
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0].name, 'flag-a');
+    assert.strictEqual(result[1].name, 'flag-c');
+  });
+
+  test('excludes features that do not intersect', () => {
+    const featureA = makeFeature('flag-a', makeRange(0, 0, 5, 0));
+    const selections = [makeSelection(10, 0, 15, 0)];
+    const result = SelectedElementsStore.filterSelectedElements(selections, [featureA]);
+    assert.strictEqual(result.length, 0);
+  });
+
+  test('works with segments', () => {
+    const segmentA = makeSegment('LA', makeRange(5, 0, 10, 0));
+    const segmentB = makeSegment('GA', makeRange(15, 0, 20, 0));
+
+    const selections = [makeSelection(7, 0, 7, 0)];
+    const result = SelectedElementsStore.filterSelectedElements(selections, [segmentA, segmentB]);
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].name, 'LA');
+  });
+
+  test('works with conditions', () => {
+    const condA = makeCondition('organization_slug', makeRange(6, 0, 8, 0));
+    const condB = makeCondition('user_email', makeRange(12, 0, 14, 0));
+
+    const selections = [makeSelection(13, 0, 13, 0)];
+    const result = SelectedElementsStore.filterSelectedElements(selections, [condA, condB]);
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].property, 'user_email');
+  });
+
+  test('cursor on boundary line is included', () => {
+    const featureA = makeFeature('flag-a', makeRange(5, 0, 10, 0));
+    const selections = [makeSelection(5, 0, 5, 0)];
+    const result = SelectedElementsStore.filterSelectedElements(selections, [featureA]);
+    assert.strictEqual(result.length, 1);
+  });
+});

--- a/src/test-utils/assert.ts
+++ b/src/test-utils/assert.ts
@@ -1,0 +1,122 @@
+class AssertionError extends Error {
+  actual: unknown;
+  expected: unknown;
+  operator: string;
+
+  constructor(opts: {actual: unknown; expected: unknown; operator: string; message?: string}) {
+    super(
+      opts.message ||
+        `Expected ${JSON.stringify(opts.actual)} ${opts.operator} ${JSON.stringify(opts.expected)}`
+    );
+    this.name = 'AssertionError';
+    this.actual = opts.actual;
+    this.expected = opts.expected;
+    this.operator = opts.operator;
+  }
+}
+
+export function strictEqual<T>(actual: unknown, expected: T, message?: string): asserts actual is T {
+  if (actual !== expected) {
+    throw new AssertionError({actual, expected, operator: '===', message});
+  }
+}
+
+export function notStrictEqual(actual: unknown, expected: unknown, message?: string): void {
+  if (actual === expected) {
+    throw new AssertionError({actual, expected, operator: '!==', message});
+  }
+}
+
+function _deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') {
+    return false;
+  }
+  if (Array.isArray(a) !== Array.isArray(b)) {
+    return false;
+  }
+  const keysA = Object.keys(a as Record<string, unknown>);
+  const keysB = Object.keys(b as Record<string, unknown>);
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+  for (const key of keysA) {
+    if (
+      !_deepEqual(
+        (a as Record<string, unknown>)[key],
+        (b as Record<string, unknown>)[key]
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function deepStrictEqual(actual: unknown, expected: unknown, message?: string): void {
+  if (!_deepEqual(actual, expected)) {
+    throw new AssertionError({actual, expected, operator: 'deepStrictEqual', message});
+  }
+}
+
+export function ok(value: unknown, message?: string): asserts value {
+  if (!value) {
+    throw new AssertionError({actual: value, expected: true, operator: '==', message});
+  }
+}
+
+export function throws(fn: () => void, expected?: RegExp | string): void {
+  try {
+    fn();
+  } catch (err) {
+    if (expected instanceof RegExp) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!expected.test(msg)) {
+        throw new AssertionError({
+          actual: msg,
+          expected: expected.toString(),
+          operator: 'throws',
+          message: `Error message "${msg}" does not match ${expected}`,
+        });
+      }
+    }
+    return;
+  }
+  throw new AssertionError({
+    actual: 'no error',
+    expected: 'error',
+    operator: 'throws',
+    message: typeof expected === 'string' ? expected : undefined,
+  });
+}
+
+export async function rejects(
+  fn: (() => Promise<unknown>) | Promise<unknown>,
+  expected?: RegExp | string,
+): Promise<void> {
+  try {
+    const promise = typeof fn === 'function' ? fn() : fn;
+    await promise;
+  } catch (err) {
+    if (expected instanceof RegExp) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!expected.test(msg)) {
+        throw new AssertionError({
+          actual: msg,
+          expected: expected.toString(),
+          operator: 'rejects',
+          message: `Error message "${msg}" does not match ${expected}`,
+        });
+      }
+    }
+    return;
+  }
+  throw new AssertionError({
+    actual: 'no rejection',
+    expected: 'rejection',
+    operator: 'rejects',
+    message: typeof expected === 'string' ? expected : undefined,
+  });
+}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import * as assert from '../test-utils/assert';
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it

--- a/src/transform/transformers.test.ts
+++ b/src/transform/transformers.test.ts
@@ -1,0 +1,598 @@
+import * as assert from '../test-utils/assert';
+import * as vscode from 'vscode';
+import {
+  LogicalValue,
+  LogicalFeature,
+  LogicalSegment,
+  logicalFeatureToFeature,
+  symbolToLogicalFeature,
+  symbolToLogicalSegment,
+  symbolToLogicalCondition,
+} from './transformers';
+
+function makeSymbol(name: string, detail: string, children: vscode.DocumentSymbol[] = []): vscode.DocumentSymbol {
+  const range = new vscode.Range(0, 0, 0, 0);
+  const sym = new vscode.DocumentSymbol(name, detail, vscode.SymbolKind.Property, range, range);
+  sym.children = children;
+  return sym;
+}
+
+const uri = vscode.Uri.parse('file:///test/flagpole.yaml');
+
+suite('transformers', () => {
+  suite('LogicalValue', () => {
+    test('constructor stores uri and value', () => {
+      const lv = new LogicalValue(uri, 'flagpole');
+      assert.strictEqual(lv.uri, uri);
+      assert.strictEqual(lv.value, 'flagpole');
+      assert.deepStrictEqual(lv.children, []);
+    });
+
+    test('addFeature appends and returns self', () => {
+      const lv = new LogicalValue(uri, 'flagpole');
+      const feature = {} as LogicalFeature;
+      const result = lv.addFeature(feature);
+      assert.strictEqual(result, lv);
+      assert.strictEqual(lv.children.length, 1);
+      assert.strictEqual(lv.children[0], feature);
+    });
+  });
+
+  suite('symbolToLogicalCondition', () => {
+    test('extracts operator, property, and value detail', () => {
+      const parent = makeSymbol('conditions', '');
+      const conditionSymbol = makeSymbol('0', '', [
+        makeSymbol('operator', 'in'),
+        makeSymbol('property', 'organization_slug'),
+        makeSymbol('value', 'sentry'),
+      ]);
+      const result = symbolToLogicalCondition(uri, parent, conditionSymbol);
+      assert.strictEqual(result.operator, 'in');
+      assert.strictEqual(result.property, 'organization_slug');
+      assert.strictEqual(result.value, 'sentry');
+      assert.strictEqual(result.uri, uri);
+      assert.strictEqual(result.symbol, conditionSymbol);
+      assert.strictEqual(result.parent, parent);
+    });
+
+    test('defaults to empty strings when children are missing', () => {
+      const parent = makeSymbol('conditions', '');
+      const conditionSymbol = makeSymbol('0', '', []);
+      const result = symbolToLogicalCondition(uri, parent, conditionSymbol);
+      assert.strictEqual(result.operator, '');
+      assert.strictEqual(result.property, '');
+      assert.deepStrictEqual(result.value, ['...']);
+    });
+
+    test('falls back to ["..."] when value detail is empty string', () => {
+      const parent = makeSymbol('conditions', '');
+      const conditionSymbol = makeSymbol('0', '', [
+        makeSymbol('operator', 'in'),
+        makeSymbol('property', 'organization_slug'),
+        makeSymbol('value', ''),
+      ]);
+      const result = symbolToLogicalCondition(uri, parent, conditionSymbol);
+      assert.deepStrictEqual(result.value, ['...']);
+    });
+  });
+
+  suite('symbolToLogicalSegment', () => {
+    test('segment with rollout 100 and conditions is partial', () => {
+      const symbol = makeSymbol('0', '', [
+        makeSymbol('name', 'is_sentry'),
+        makeSymbol('rollout', '100'),
+        makeSymbol('conditions', '', [
+          makeSymbol('0', '', [
+            makeSymbol('operator', 'in'),
+            makeSymbol('property', 'organization_slug'),
+            makeSymbol('value', 'sentry'),
+          ]),
+        ]),
+      ]);
+      const result = symbolToLogicalSegment(uri, symbol);
+      assert.strictEqual(result.name, 'is_sentry');
+      assert.strictEqual(result.rollout, 100);
+      assert.strictEqual(result.rolloutState, 'partial');
+      assert.strictEqual(result.conditions.length, 1);
+    });
+
+    test('segment with rollout 100 and no conditions is 100%', () => {
+      const symbol = makeSymbol('0', '', [
+        makeSymbol('name', 'GA'),
+        makeSymbol('rollout', '100'),
+        makeSymbol('conditions', '', []),
+      ]);
+      const result = symbolToLogicalSegment(uri, symbol);
+      assert.strictEqual(result.rolloutState, '100%');
+      assert.strictEqual(result.rollout, 100);
+    });
+
+    test('segment with no rollout field and no conditions is 100%', () => {
+      const symbol = makeSymbol('0', '', [
+        makeSymbol('name', 'GA'),
+        makeSymbol('conditions', '', []),
+      ]);
+      const result = symbolToLogicalSegment(uri, symbol);
+      assert.strictEqual(result.rolloutState, '100%');
+      assert.strictEqual(result.rollout, 100);
+    });
+
+    test('segment with no rollout field and conditions is partial', () => {
+      const symbol = makeSymbol('0', '', [
+        makeSymbol('name', 'EA'),
+        makeSymbol('conditions', '', [
+          makeSymbol('0', '', [
+            makeSymbol('operator', 'equals'),
+            makeSymbol('property', 'organization_is-early-adopter'),
+            makeSymbol('value', 'true'),
+          ]),
+        ]),
+      ]);
+      const result = symbolToLogicalSegment(uri, symbol);
+      assert.strictEqual(result.rolloutState, 'partial');
+      assert.strictEqual(result.rollout, 100);
+    });
+
+    test('segment with rollout 0 is 0%', () => {
+      const symbol = makeSymbol('0', '', [
+        makeSymbol('name', 'dev'),
+        makeSymbol('rollout', '0'),
+        makeSymbol('conditions', '', [
+          makeSymbol('0', '', [
+            makeSymbol('operator', 'in'),
+            makeSymbol('property', 'organization_slug'),
+            makeSymbol('value', 'sentry'),
+          ]),
+        ]),
+      ]);
+      const result = symbolToLogicalSegment(uri, symbol);
+      assert.strictEqual(result.rolloutState, '0%');
+      assert.strictEqual(result.rollout, 0);
+    });
+
+    test('segment with rollout 50 and conditions is partial', () => {
+      const symbol = makeSymbol('0', '', [
+        makeSymbol('name', 'gradual'),
+        makeSymbol('rollout', '50'),
+        makeSymbol('conditions', '', [
+          makeSymbol('0', '', [
+            makeSymbol('operator', 'in'),
+            makeSymbol('property', 'subscription_plan-tier'),
+            makeSymbol('value', 'am3'),
+          ]),
+        ]),
+      ]);
+      const result = symbolToLogicalSegment(uri, symbol);
+      assert.strictEqual(result.rolloutState, 'partial');
+      assert.strictEqual(result.rollout, 50);
+    });
+
+    test('segment with rollout 50 and no conditions is partial', () => {
+      const symbol = makeSymbol('0', '', [
+        makeSymbol('name', 'gradual'),
+        makeSymbol('rollout', '50'),
+        makeSymbol('conditions', '', []),
+      ]);
+      const result = symbolToLogicalSegment(uri, symbol);
+      assert.strictEqual(result.rolloutState, 'partial');
+      assert.strictEqual(result.rollout, 50);
+    });
+
+    test('segment with no conditions symbol defaults to empty', () => {
+      const symbol = makeSymbol('0', '', [
+        makeSymbol('name', 'bare'),
+        makeSymbol('rollout', '100'),
+      ]);
+      const result = symbolToLogicalSegment(uri, symbol);
+      assert.strictEqual(result.conditions.length, 0);
+      assert.strictEqual(result.conditionsSymbol, undefined);
+      assert.strictEqual(result.rolloutState, '100%');
+    });
+
+    test('segment with no name defaults to empty string', () => {
+      const symbol = makeSymbol('0', '', [
+        makeSymbol('rollout', '100'),
+        makeSymbol('conditions', '', []),
+      ]);
+      const result = symbolToLogicalSegment(uri, symbol);
+      assert.strictEqual(result.name, '');
+    });
+
+    test('preserves uri and symbol references', () => {
+      const symbol = makeSymbol('0', '', [
+        makeSymbol('name', 'test'),
+        makeSymbol('rollout', '100'),
+        makeSymbol('conditions', '', []),
+      ]);
+      const result = symbolToLogicalSegment(uri, symbol);
+      assert.strictEqual(result.uri, uri);
+      assert.strictEqual(result.symbol, symbol);
+    });
+  });
+
+  suite('symbolToLogicalFeature', () => {
+    test('feature with one partial segment is partial', () => {
+      const symbol = makeSymbol('feature.organizations:inbound-filters-v2', '', [
+        makeSymbol('created_at', '2026-05-29'),
+        makeSymbol('enabled', 'true'),
+        makeSymbol('owner', 'telemetry-experience'),
+        makeSymbol('segments', '', [
+          makeSymbol('0', '', [
+            makeSymbol('name', 'IA'),
+            makeSymbol('rollout', '100'),
+            makeSymbol('conditions', '', [
+              makeSymbol('0', '', [
+                makeSymbol('operator', 'in'),
+                makeSymbol('property', 'organization_slug'),
+                makeSymbol('value', 'simon-test-us'),
+              ]),
+            ]),
+          ]),
+        ]),
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.name, 'feature.organizations:inbound-filters-v2');
+      assert.strictEqual(result.created_at, '2026-05-29');
+      assert.strictEqual(result.enabled, true);
+      assert.strictEqual(result.owner, 'telemetry-experience');
+      assert.strictEqual(result.rolloutState, 'partial');
+      assert.strictEqual(result.segments.length, 1);
+      assert.strictEqual(result.hasExtraSegments, false);
+    });
+
+    test('feature with 100% segment becomes 100%', () => {
+      const symbol = makeSymbol('feature.organizations:full-rollout', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('enabled', 'true'),
+        makeSymbol('owner', 'team-x'),
+        makeSymbol('segments', '', [
+          makeSymbol('0', '', [
+            makeSymbol('name', 'GA'),
+            makeSymbol('rollout', '100'),
+            makeSymbol('conditions', '', []),
+          ]),
+        ]),
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.rolloutState, '100%');
+      assert.strictEqual(result.hasExtraSegments, false);
+    });
+
+    test('feature at 100% with last segment having conditions sets hasExtraSegments', () => {
+      const symbol = makeSymbol('feature.organizations:extra-segments', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('enabled', 'true'),
+        makeSymbol('owner', 'team-x'),
+        makeSymbol('segments', '', [
+          makeSymbol('0', '', [
+            makeSymbol('name', 'GA'),
+            makeSymbol('rollout', '100'),
+            makeSymbol('conditions', '', []),
+          ]),
+          makeSymbol('1', '', [
+            makeSymbol('name', 'LA'),
+            makeSymbol('rollout', '100'),
+            makeSymbol('conditions', '', [
+              makeSymbol('0', '', [
+                makeSymbol('operator', 'in'),
+                makeSymbol('property', 'organization_slug'),
+                makeSymbol('value', 'sentry'),
+              ]),
+            ]),
+          ]),
+        ]),
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.rolloutState, '100%');
+      assert.strictEqual(result.hasExtraSegments, true);
+    });
+
+    test('feature with all 0% segments is 0%', () => {
+      const symbol = makeSymbol('feature.organizations:disabled-flag', '', [
+        makeSymbol('created_at', '2025-06-06'),
+        makeSymbol('enabled', 'true'),
+        makeSymbol('owner', 'issue_detection'),
+        makeSymbol('segments', '', [
+          makeSymbol('0', '', [
+            makeSymbol('name', 'GA'),
+            makeSymbol('rollout', '0'),
+            makeSymbol('conditions', '', []),
+          ]),
+        ]),
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.rolloutState, '0%');
+      assert.strictEqual(result.hasExtraSegments, false);
+    });
+
+    test('feature with no segments is 0%', () => {
+      const symbol = makeSymbol('feature.organizations:no-segments', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('enabled', 'true'),
+        makeSymbol('owner', 'team-x'),
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.rolloutState, '0%');
+      assert.strictEqual(result.segments.length, 0);
+      assert.strictEqual(result.segmentsSymbol, undefined);
+    });
+
+    test('enabled defaults to true when omitted', () => {
+      const symbol = makeSymbol('feature.organizations:no-enabled', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('owner', 'team-x'),
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.enabled, true);
+    });
+
+    test('enabled: false is detected', () => {
+      const symbol = makeSymbol('feature.organizations:disabled', '', [
+        makeSymbol('created_at', '2026-02-23'),
+        makeSymbol('enabled', 'false'),
+        makeSymbol('owner', 'issue_detection'),
+        makeSymbol('segments', '', [
+          makeSymbol('0', '', [
+            makeSymbol('name', 'LA'),
+            makeSymbol('rollout', '100'),
+            makeSymbol('conditions', '', [
+              makeSymbol('0', '', [
+                makeSymbol('operator', 'in'),
+                makeSymbol('property', 'organization_slug'),
+                makeSymbol('value', 'sentry'),
+              ]),
+            ]),
+          ]),
+        ]),
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.enabled, false);
+    });
+
+    test('owner from detail string (team shorthand)', () => {
+      const symbol = makeSymbol('feature.organizations:team-owner', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('owner', 'alerts-notifications'),
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.owner, 'alerts-notifications');
+    });
+
+    test('owner from email child when detail is empty', () => {
+      const ownerSymbol = makeSymbol('owner', '', [
+        makeSymbol('email', 'shayna.chambless@sentry.io'),
+        makeSymbol('team', 'issue_detection'),
+      ]);
+      const symbol = makeSymbol('feature.organizations:email-owner', '', [
+        makeSymbol('created_at', '2025-12-11'),
+        ownerSymbol,
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.owner, 'shayna.chambless@sentry.io');
+    });
+
+    test('owner from team child when no email child', () => {
+      const ownerSymbol = makeSymbol('owner', '', [
+        makeSymbol('team', 'data-browsing'),
+      ]);
+      const symbol = makeSymbol('feature.organizations:team-child-owner', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        ownerSymbol,
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.owner, 'data-browsing');
+    });
+
+    test('owner defaults to empty string when missing', () => {
+      const symbol = makeSymbol('feature.organizations:no-owner', '', [
+        makeSymbol('created_at', '2025-01-01'),
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.owner, '');
+    });
+
+    test('created_at defaults to empty string when missing', () => {
+      const symbol = makeSymbol('feature.organizations:no-date', '', [
+        makeSymbol('owner', 'team-x'),
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.created_at, '');
+    });
+
+    test('multiple segments — partial wins if no 100%', () => {
+      const symbol = makeSymbol('feature.organizations:multi-segment', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('enabled', 'true'),
+        makeSymbol('owner', 'team-x'),
+        makeSymbol('segments', '', [
+          makeSymbol('0', '', [
+            makeSymbol('name', 'LA'),
+            makeSymbol('rollout', '100'),
+            makeSymbol('conditions', '', [
+              makeSymbol('0', '', [
+                makeSymbol('operator', 'in'),
+                makeSymbol('property', 'organization_slug'),
+                makeSymbol('value', 'sentry'),
+              ]),
+            ]),
+          ]),
+          makeSymbol('1', '', [
+            makeSymbol('name', 'EA'),
+            makeSymbol('rollout', '0'),
+            makeSymbol('conditions', '', []),
+          ]),
+        ]),
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.rolloutState, 'partial');
+    });
+
+    test('100% wins over partial in mixed segments', () => {
+      const symbol = makeSymbol('feature.organizations:mixed', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('enabled', 'true'),
+        makeSymbol('owner', 'team-x'),
+        makeSymbol('segments', '', [
+          makeSymbol('0', '', [
+            makeSymbol('name', 'LA'),
+            makeSymbol('rollout', '100'),
+            makeSymbol('conditions', '', [
+              makeSymbol('0', '', [
+                makeSymbol('operator', 'in'),
+                makeSymbol('property', 'organization_slug'),
+                makeSymbol('value', 'sentry'),
+              ]),
+            ]),
+          ]),
+          makeSymbol('1', '', [
+            makeSymbol('name', 'GA'),
+            makeSymbol('rollout', '100'),
+            makeSymbol('conditions', '', []),
+          ]),
+        ]),
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.rolloutState, '100%');
+    });
+
+    test('feature with rollout 50 and empty conditions is partial', () => {
+      const ownerSymbol = makeSymbol('owner', '', [
+        makeSymbol('team', 'ml-ai'),
+      ]);
+      const symbol = makeSymbol('feature.organizations:rollout-50-empty-conditions', '', [
+        makeSymbol('created_at', '2026-06-01'),
+        makeSymbol('enabled', 'true'),
+        ownerSymbol,
+        makeSymbol('segments', '', [
+          makeSymbol('0', '', [
+            makeSymbol('conditions', '', []),
+            makeSymbol('name', 'GA'),
+            makeSymbol('rollout', '50'),
+          ]),
+        ]),
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.name, 'feature.organizations:rollout-50-empty-conditions');
+      assert.strictEqual(result.created_at, '2026-06-01');
+      assert.strictEqual(result.enabled, true);
+      assert.strictEqual(result.owner, 'ml-ai');
+      assert.strictEqual(result.rolloutState, 'partial');
+      assert.strictEqual(result.segments.length, 1);
+      assert.strictEqual(result.segments[0].name, 'GA');
+      assert.strictEqual(result.segments[0].rollout, 50);
+      assert.strictEqual(result.segments[0].conditions.length, 0);
+      assert.strictEqual(result.segments[0].rolloutState, 'partial');
+      assert.strictEqual(result.hasExtraSegments, false);
+    });
+
+    test('preserves uri and symbol references', () => {
+      const symbol = makeSymbol('feature.organizations:refs', '', [
+        makeSymbol('created_at', '2025-01-01'),
+        makeSymbol('owner', 'team-x'),
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.uri, uri);
+      assert.strictEqual(result.symbol, symbol);
+    });
+  });
+
+  suite('logicalFeatureToFeature', () => {
+    function makeLogicalFeature(overrides: Partial<LogicalFeature> = {}): LogicalFeature {
+      const range = new vscode.Range(0, 0, 0, 0);
+      return {
+        symbol: new vscode.DocumentSymbol('test', '', vscode.SymbolKind.Property, range, range),
+        uri,
+        name: 'feature.organizations:test',
+        created_at: '2025-01-01',
+        enabled: true,
+        owner: 'team-x',
+        segmentsSymbol: undefined,
+        segments: [],
+        rolloutState: '0%',
+        hasExtraSegments: false,
+        ...overrides,
+      };
+    }
+
+    function makeLogicalSegment(overrides: Partial<LogicalSegment> = {}): LogicalSegment {
+      const range = new vscode.Range(0, 0, 0, 0);
+      return {
+        symbol: new vscode.DocumentSymbol('seg', '', vscode.SymbolKind.Property, range, range),
+        uri,
+        name: 'GA',
+        rollout: 100,
+        conditionsSymbol: undefined,
+        conditions: [],
+        rolloutState: '100%',
+        ...overrides,
+      };
+    }
+
+    test('converts a feature with no segments', () => {
+      const logical = makeLogicalFeature();
+      const feature = logicalFeatureToFeature(logical);
+      assert.strictEqual(feature.name, 'feature.organizations:test');
+      assert.strictEqual(feature.definition.created_at, '2025-01-01');
+      assert.strictEqual(feature.definition.enabled, true);
+      assert.strictEqual(feature.definition.owner, 'team-x');
+      assert.deepStrictEqual(feature.definition.segments, []);
+      assert.strictEqual(feature.rollout, '0%');
+    });
+
+    test('converts segments with conditions', () => {
+      const range = new vscode.Range(0, 0, 0, 0);
+      const condParent = new vscode.DocumentSymbol('conditions', '', vscode.SymbolKind.Property, range, range);
+      const condSymbol = new vscode.DocumentSymbol('0', '', vscode.SymbolKind.Property, range, range);
+      const logical = makeLogicalFeature({
+        rolloutState: 'partial',
+        segments: [
+          makeLogicalSegment({
+            name: 'IA',
+            rollout: 100,
+            rolloutState: 'partial',
+            conditions: [
+              {
+                symbol: condSymbol,
+                parent: condParent,
+                uri,
+                property: 'organization_slug',
+                operator: 'in',
+                value: 'sentry',
+              },
+            ],
+          }),
+        ],
+      });
+      const feature = logicalFeatureToFeature(logical);
+      assert.strictEqual(feature.definition.segments.length, 1);
+      assert.strictEqual(feature.definition.segments[0].name, 'IA');
+      assert.strictEqual(feature.definition.segments[0].rollout, 100);
+      assert.strictEqual(feature.definition.segments[0].conditions.length, 1);
+      assert.strictEqual(feature.definition.segments[0].conditions[0].property, 'organization_slug');
+      assert.strictEqual(feature.definition.segments[0].conditions[0].operator, 'in');
+      assert.strictEqual(feature.definition.segments[0].conditions[0].value, 'sentry');
+    });
+
+    test('strips symbol/uri fields from output', () => {
+      const logical = makeLogicalFeature({
+        segments: [makeLogicalSegment()],
+      });
+      const feature = logicalFeatureToFeature(logical);
+      const segment = feature.definition.segments[0] as Record<string, unknown>;
+      assert.strictEqual(segment['symbol'], undefined);
+      assert.strictEqual(segment['uri'], undefined);
+      assert.strictEqual(segment['conditionsSymbol'], undefined);
+    });
+
+    test('maps rolloutState to rollout field', () => {
+      const partial = logicalFeatureToFeature(makeLogicalFeature({ rolloutState: 'partial' }));
+      assert.strictEqual(partial.rollout, 'partial');
+
+      const full = logicalFeatureToFeature(makeLogicalFeature({ rolloutState: '100%' }));
+      assert.strictEqual(full.rollout, '100%');
+
+      const zero = logicalFeatureToFeature(makeLogicalFeature({ rolloutState: '0%' }));
+      assert.strictEqual(zero.rollout, '0%');
+    });
+  });
+});

--- a/src/treeview/treeViewItems.test.ts
+++ b/src/treeview/treeViewItems.test.ts
@@ -1,0 +1,141 @@
+import * as assert from '../test-utils/assert';
+import * as vscode from 'vscode';
+import { FileTreeItem, ValueTreeItem, FeatureTreeItem } from './treeViewItems';
+import { LogicalFeature, LogicalValue } from '../transform/transformers';
+
+const uri = vscode.Uri.parse('file:///test/flagpole.yaml');
+
+function makeSymbol(name: string, range?: vscode.Range): vscode.DocumentSymbol {
+  const r = range ?? new vscode.Range(0, 0, 0, 0);
+  return new vscode.DocumentSymbol(name, '', vscode.SymbolKind.Property, r, r);
+}
+
+function makeLogicalFeature(overrides: Partial<LogicalFeature> = {}): LogicalFeature {
+  return {
+    symbol: makeSymbol('feature.organizations:test'),
+    uri,
+    name: 'feature.organizations:test',
+    created_at: '2025-01-01',
+    enabled: true,
+    owner: 'team-x',
+    segmentsSymbol: undefined,
+    segments: [],
+    rolloutState: '0%',
+    hasExtraSegments: false,
+    ...overrides,
+  };
+}
+
+suite('treeViewItems', () => {
+  suite('FileTreeItem', () => {
+    test('sets label to uri', () => {
+      const item = new FileTreeItem(uri, '42');
+      assert.strictEqual(item.resourceUri, uri);
+    });
+
+    test('sets description', () => {
+      const item = new FileTreeItem(uri, '42');
+      assert.strictEqual(item.description, '42');
+    });
+
+    test('is expanded by default', () => {
+      const item = new FileTreeItem(uri, '5');
+      assert.strictEqual(item.collapsibleState, vscode.TreeItemCollapsibleState.Expanded);
+    });
+
+    test('uses json icon', () => {
+      const item = new FileTreeItem(uri, '0');
+      assert.ok(item.iconPath instanceof vscode.ThemeIcon);
+      assert.strictEqual((item.iconPath as vscode.ThemeIcon).id, 'json');
+    });
+  });
+
+  suite('ValueTreeItem', () => {
+    test('sets label from element value', () => {
+      const element = new LogicalValue(uri, 'team-alpha');
+      const item = new ValueTreeItem(element, () => undefined);
+      assert.strictEqual(item.label, 'team-alpha');
+    });
+
+    test('sets description to child count', () => {
+      const element = new LogicalValue(uri, 'team-alpha');
+      element.addFeature(makeLogicalFeature({ name: 'flag-a' }));
+      element.addFeature(makeLogicalFeature({ name: 'flag-b' }));
+      const item = new ValueTreeItem(element, () => undefined);
+      assert.strictEqual(item.description, '2');
+    });
+
+    test('is collapsed by default', () => {
+      const element = new LogicalValue(uri, 'test');
+      const item = new ValueTreeItem(element, () => undefined);
+      assert.strictEqual(item.collapsibleState, vscode.TreeItemCollapsibleState.Collapsed);
+    });
+
+    test('uses icon from callback', () => {
+      const element = new LogicalValue(uri, 'test');
+      const icon = new vscode.ThemeIcon('pass-filled');
+      const item = new ValueTreeItem(element, () => icon);
+      assert.strictEqual(item.iconPath, icon);
+    });
+
+    test('allows undefined icon', () => {
+      const element = new LogicalValue(uri, 'test');
+      const item = new ValueTreeItem(element, () => undefined);
+      assert.strictEqual(item.iconPath, undefined);
+    });
+  });
+
+  suite('FeatureTreeItem', () => {
+    test('sets label to feature name', () => {
+      const feature = makeLogicalFeature({ name: 'feature.organizations:my-flag' });
+      const item = new FeatureTreeItem(feature);
+      assert.strictEqual(item.label, 'feature.organizations:my-flag');
+    });
+
+    test('is not collapsible', () => {
+      const feature = makeLogicalFeature();
+      const item = new FeatureTreeItem(feature);
+      assert.strictEqual(item.collapsibleState, vscode.TreeItemCollapsibleState.None);
+    });
+
+    test('has a go-to-location command', () => {
+      const feature = makeLogicalFeature();
+      const item = new FeatureTreeItem(feature);
+      assert.ok(item.command);
+      assert.strictEqual(item.command.command, 'editor.action.goToLocations');
+      assert.strictEqual(item.command.title, 'view');
+    });
+
+    test('command arguments include feature uri and range', () => {
+      const range = new vscode.Range(10, 2, 15, 0);
+      const symbol = makeSymbol('test', range);
+      const feature = makeLogicalFeature({ symbol, uri });
+      const item = new FeatureTreeItem(feature);
+      assert.ok(item.command);
+      assert.ok(item.command.arguments);
+      assert.strictEqual(item.command.arguments[0], uri);
+      assert.ok(item.command.arguments[1].isEqual(range.start));
+    });
+
+    test('icon reflects rollout state 0%', () => {
+      const feature = makeLogicalFeature({ rolloutState: '0%' });
+      const item = new FeatureTreeItem(feature);
+      assert.ok(item.iconPath instanceof vscode.ThemeIcon);
+      assert.strictEqual((item.iconPath as vscode.ThemeIcon).id, 'circle-large-outline');
+    });
+
+    test('icon reflects rollout state partial', () => {
+      const feature = makeLogicalFeature({ rolloutState: 'partial' });
+      const item = new FeatureTreeItem(feature);
+      assert.ok(item.iconPath instanceof vscode.ThemeIcon);
+      assert.strictEqual((item.iconPath as vscode.ThemeIcon).id, 'color-mode');
+    });
+
+    test('icon reflects rollout state 100%', () => {
+      const feature = makeLogicalFeature({ rolloutState: '100%' });
+      const item = new FeatureTreeItem(feature);
+      assert.ok(item.iconPath instanceof vscode.ThemeIcon);
+      assert.strictEqual((item.iconPath as vscode.ThemeIcon).id, 'pass-filled');
+    });
+  });
+});

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,0 +1,138 @@
+import * as assert from './test-utils/assert';
+import {
+  FEATURE_NAME_PATTERN,
+  FEATURE_NAME_LINE,
+  PROPERTIES,
+  OPERATORS,
+} from './types';
+
+suite('types', () => {
+  suite('FEATURE_NAME_PATTERN', () => {
+    test('matches organization feature names', () => {
+      assert.ok(FEATURE_NAME_PATTERN.test('feature.organizations:my-flag'));
+      assert.ok(FEATURE_NAME_PATTERN.test('feature.organizations:workflow-engine-ui'));
+      assert.ok(FEATURE_NAME_PATTERN.test('feature.organizations:issue-performance-n-plus-one-api-calls-experimental-visible'));
+    });
+
+    test('matches project feature names', () => {
+      assert.ok(FEATURE_NAME_PATTERN.test('feature.projects:transaction-name-clustering-disabled'));
+      assert.ok(FEATURE_NAME_PATTERN.test('feature.projects:my-project-flag'));
+    });
+
+    test('matches names with dots and underscores', () => {
+      assert.ok(FEATURE_NAME_PATTERN.test('feature.organizations:some_flag'));
+      assert.ok(FEATURE_NAME_PATTERN.test('feature.organizations:some.flag'));
+    });
+
+    test('matches names with numbers', () => {
+      assert.ok(FEATURE_NAME_PATTERN.test('feature.organizations:inbound-filters-v2'));
+      assert.ok(FEATURE_NAME_PATTERN.test('feature.organizations:am3-tier'));
+    });
+
+    test('rejects names without feature prefix', () => {
+      assert.ok(!FEATURE_NAME_PATTERN.test('organizations:my-flag'));
+      assert.ok(!FEATURE_NAME_PATTERN.test('my-flag'));
+    });
+
+    test('rejects names without scope', () => {
+      assert.ok(!FEATURE_NAME_PATTERN.test('feature:my-flag'));
+      assert.ok(!FEATURE_NAME_PATTERN.test('feature.my-flag'));
+    });
+
+    test('rejects unknown scopes', () => {
+      assert.ok(!FEATURE_NAME_PATTERN.test('feature.users:my-flag'));
+      assert.ok(!FEATURE_NAME_PATTERN.test('feature.teams:my-flag'));
+    });
+
+    test('rejects uppercase characters', () => {
+      assert.ok(!FEATURE_NAME_PATTERN.test('feature.organizations:MyFlag'));
+      assert.ok(!FEATURE_NAME_PATTERN.test('feature.organizations:MY-FLAG'));
+    });
+
+    test('rejects empty flag name after colon', () => {
+      assert.ok(!FEATURE_NAME_PATTERN.test('feature.organizations:'));
+    });
+
+    test('rejects names with spaces', () => {
+      assert.ok(!FEATURE_NAME_PATTERN.test('feature.organizations:my flag'));
+    });
+  });
+
+  suite('FEATURE_NAME_LINE', () => {
+    test('matches unquoted YAML key lines', () => {
+      assert.ok(FEATURE_NAME_LINE.test('  feature.organizations:workflow-engine-ui:'));
+      assert.ok(FEATURE_NAME_LINE.test('  feature.projects:transaction-name-clustering-disabled:'));
+    });
+
+    test('matches quoted YAML key lines', () => {
+      assert.ok(FEATURE_NAME_LINE.test('  "feature.organizations:continuous-profiling":'));
+      assert.ok(FEATURE_NAME_LINE.test('  "feature.organizations:inbound-filters-v2":'));
+    });
+
+    test('matches with various leading whitespace', () => {
+      assert.ok(FEATURE_NAME_LINE.test('feature.organizations:my-flag:'));
+      assert.ok(FEATURE_NAME_LINE.test('    feature.organizations:my-flag:'));
+      assert.ok(FEATURE_NAME_LINE.test('\tfeature.organizations:my-flag:'));
+    });
+
+    test('rejects lines that are not feature definitions', () => {
+      assert.ok(!FEATURE_NAME_LINE.test('  created_at: "2025-01-01"'));
+      assert.ok(!FEATURE_NAME_LINE.test('  enabled: true'));
+      assert.ok(!FEATURE_NAME_LINE.test('  owner:'));
+    });
+
+    test('rejects feature references in values', () => {
+      assert.ok(!FEATURE_NAME_LINE.test('    value: feature.organizations:some-flag'));
+    });
+  });
+
+  suite('PROPERTIES', () => {
+    test('contains all expected property names', () => {
+      const names = Object.keys(PROPERTIES);
+      assert.ok(names.includes('organization_slug'));
+      assert.ok(names.includes('organization_id'));
+      assert.ok(names.includes('project_id'));
+      assert.ok(names.includes('user_email'));
+      assert.ok(names.includes('subscription_plan-tier'));
+      assert.ok(names.includes('sentry_region'));
+    });
+
+    test('property types are valid', () => {
+      const validTypes = ['number', 'string', 'boolean'];
+      for (const [name, type] of Object.entries(PROPERTIES)) {
+        assert.ok(validTypes.includes(type), `${name} has invalid type: ${type}`);
+      }
+    });
+
+    test('project_id is number type', () => {
+      assert.strictEqual(PROPERTIES['project_id'], 'number');
+    });
+
+    test('organization_slug is string type', () => {
+      assert.strictEqual(PROPERTIES['organization_slug'], 'string');
+    });
+
+    test('boolean properties are typed correctly', () => {
+      assert.strictEqual(PROPERTIES['organization_is-early-adopter'], 'boolean');
+      assert.strictEqual(PROPERTIES['user_is-staff'], 'boolean');
+      assert.strictEqual(PROPERTIES['user_is-superuser'], 'boolean');
+      assert.strictEqual(PROPERTIES['subscription_is-free'], 'boolean');
+      assert.strictEqual(PROPERTIES['sentry_singletenant'], 'boolean');
+    });
+  });
+
+  suite('OPERATORS', () => {
+    test('contains all six operators', () => {
+      assert.strictEqual(OPERATORS.length, 6);
+    });
+
+    test('includes each expected operator', () => {
+      assert.ok(OPERATORS.includes('in'));
+      assert.ok(OPERATORS.includes('not_in'));
+      assert.ok(OPERATORS.includes('contains'));
+      assert.ok(OPERATORS.includes('not_contains'));
+      assert.ok(OPERATORS.includes('equals'));
+      assert.ok(OPERATORS.includes('not_equals'));
+    });
+  });
+});

--- a/src/utils/createTimeoutPromise.test.ts
+++ b/src/utils/createTimeoutPromise.test.ts
@@ -1,0 +1,77 @@
+import * as assert from '../test-utils/assert';
+import * as vscode from 'vscode';
+import { createTimeoutPromise } from './createTimeoutPromise';
+
+suite('createTimeoutPromise', () => {
+  test('resolves when onSetup calls resolve', async () => {
+    const result = await createTimeoutPromise<string>(5000, 'test-resolve', (resolve) => {
+      resolve('hello');
+      return new vscode.Disposable(() => {});
+    });
+    assert.strictEqual(result, 'hello');
+  });
+
+  test('rejects when onSetup calls reject', async () => {
+    await assert.rejects(
+      () => createTimeoutPromise<string>(5000, 'test-reject', (_resolve, reject) => {
+        reject(new Error('manual reject'));
+        return new vscode.Disposable(() => {});
+      }),
+      /manual reject/,
+    );
+  });
+
+  test('rejects on timeout', async () => {
+    await assert.rejects(
+      () => createTimeoutPromise<string>(50, 'test-timeout', () => {
+        return new vscode.Disposable(() => {});
+      }),
+      /test-timeout timeout after 50ms/,
+    );
+  });
+
+  test('disposes subscription on resolve', async () => {
+    let disposed = false;
+    await createTimeoutPromise<string>(5000, 'test-dispose-resolve', (resolve) => {
+      resolve('ok');
+      return new vscode.Disposable(() => { disposed = true; });
+    });
+    assert.strictEqual(disposed, true);
+  });
+
+  test('disposes subscription on reject', async () => {
+    let disposed = false;
+    await createTimeoutPromise<string>(5000, 'test-dispose-reject', (_resolve, reject) => {
+      reject(new Error('fail'));
+      return new vscode.Disposable(() => { disposed = true; });
+    }).catch(() => {});
+    assert.strictEqual(disposed, true);
+  });
+
+  test('disposes subscription on timeout', async () => {
+    let disposed = false;
+    await createTimeoutPromise<string>(50, 'test-dispose-timeout', () => {
+      return new vscode.Disposable(() => { disposed = true; });
+    }).catch(() => {});
+    assert.strictEqual(disposed, true);
+  });
+
+  test('clears timeout after resolve', async () => {
+    let disposed = false;
+    await createTimeoutPromise<string>(50, 'test-clear-timeout', (resolve) => {
+      resolve('fast');
+      return new vscode.Disposable(() => { disposed = true; });
+    });
+    // Wait longer than the timeout to ensure it doesn't fire after resolve
+    await new Promise(r => setTimeout(r, 100));
+    assert.strictEqual(disposed, true);
+  });
+
+  test('resolves with async callback', async () => {
+    const result = await createTimeoutPromise<number>(5000, 'test-async', (resolve) => {
+      setTimeout(() => resolve(42), 10);
+      return new vscode.Disposable(() => {});
+    });
+    assert.strictEqual(result, 42);
+  });
+});

--- a/src/utils/createTimeoutPromise.ts
+++ b/src/utils/createTimeoutPromise.ts
@@ -9,25 +9,23 @@ export function createTimeoutPromise<T>(
   timeout: number,
   operation: string,
   onSetup: (resolve: (value: T) => void, reject: (error: Error) => void) => vscode.Disposable): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const rejectionTimeout = setTimeout(() => {
+  let rejectionTimeout: ReturnType<typeof setTimeout>;
+  let subscription: vscode.Disposable;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    rejectionTimeout = setTimeout(() => {
       const error = new Error(`${operation} timeout after ${timeout}ms`);
       captureException(error, { context: 'terminal', operation });
       reject(error);
-      subscription.dispose();
     }, timeout);
+  });
 
-    const subscription = onSetup(
-      (value) => {
-        resolve(value);
-        subscription.dispose();
-        clearTimeout(rejectionTimeout);
-      },
-      (error) => {
-        reject(error);
-        subscription.dispose();
-        clearTimeout(rejectionTimeout);
-      }
-    );
+  const operationPromise = new Promise<T>((resolve, reject) => {
+    subscription = onSetup(resolve, reject);
+  });
+
+  return Promise.race([operationPromise, timeoutPromise]).finally(() => {
+    clearTimeout(rejectionTimeout);
+    subscription.dispose();
   });
 }

--- a/src/utils/getRolloutEmoji.test.ts
+++ b/src/utils/getRolloutEmoji.test.ts
@@ -1,0 +1,23 @@
+import * as assert from '../test-utils/assert';
+import getRolloutEmoji from './getRolloutEmoji';
+
+suite('getRolloutEmoji', () => {
+  test('returns circle for 0%', () => {
+    assert.strictEqual(getRolloutEmoji('0%'), '⭕');
+  });
+
+  test('returns orange for partial', () => {
+    assert.strictEqual(getRolloutEmoji('partial'), '🟠');
+  });
+
+  test('returns green for 100%', () => {
+    assert.strictEqual(getRolloutEmoji('100%'), '🟢');
+  });
+
+  test('throws for unknown state', () => {
+    assert.throws(
+      () => getRolloutEmoji('unknown' as any),
+      /Unknown rollout state: unknown/,
+    );
+  });
+});

--- a/src/utils/getRolloutStateIconPath.test.ts
+++ b/src/utils/getRolloutStateIconPath.test.ts
@@ -1,0 +1,29 @@
+import * as assert from '../test-utils/assert';
+import * as vscode from 'vscode';
+import { getRolloutStateIconPath } from './getRolloutStateIconPath';
+
+suite('getRolloutStateIconPath', () => {
+  test('0% returns circle-large-outline with red color', () => {
+    const icon = getRolloutStateIconPath('0%');
+    assert.ok(icon instanceof vscode.ThemeIcon);
+    assert.strictEqual(icon.id, 'circle-large-outline');
+  });
+
+  test('partial returns color-mode with yellow color', () => {
+    const icon = getRolloutStateIconPath('partial');
+    assert.ok(icon instanceof vscode.ThemeIcon);
+    assert.strictEqual(icon.id, 'color-mode');
+  });
+
+  test('100% returns pass-filled with green color', () => {
+    const icon = getRolloutStateIconPath('100%');
+    assert.ok(icon instanceof vscode.ThemeIcon);
+    assert.strictEqual(icon.id, 'pass-filled');
+  });
+
+  test('unknown state returns question icon', () => {
+    const icon = getRolloutStateIconPath('unknown' as any);
+    assert.ok(icon instanceof vscode.ThemeIcon);
+    assert.strictEqual(icon.id, 'question');
+  });
+});

--- a/src/web/test/suite/extensionTests.ts
+++ b/src/web/test/suite/extensionTests.ts
@@ -1,0 +1,4 @@
+// This file is a placeholder entry point.
+// The testBundlePlugin in esbuild.js intercepts it and generates the actual
+// contents that import the mocha runner and all *.test.ts files.
+export { run } from './mochaTestRunner';

--- a/src/web/test/suite/mochaTestRunner.ts
+++ b/src/web/test/suite/mochaTestRunner.ts
@@ -1,0 +1,29 @@
+// @ts-ignore
+require('mocha/mocha');
+
+mocha.setup({
+  ui: 'tdd',
+  reporter: undefined,
+});
+
+export function run(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    // The esbuild testBundlePlugin generates dynamic imports (Promise.resolve().then(...))
+    // for each test file. These resolve as microtasks after the current execution context.
+    // Use setTimeout to defer mocha.run() until all test suites have registered.
+    setTimeout(() => {
+      try {
+        mocha.run(failures => {
+          if (failures > 0) {
+            reject(new Error(`${failures} tests failed.`));
+          } else {
+            resolve();
+          }
+        });
+      } catch (err) {
+        console.error(err);
+        reject(err);
+      }
+    }, 0);
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,6 +455,23 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@koa/cors@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@koa/cors/-/cors-5.0.0.tgz#0029b5f057fa0d0ae0e37dd2c89ece315a0daffd"
+  integrity sha512-x/iUDjcS90W69PryLDIMgFyV21YLTnG9zOpPXS7Bkt2b8AsY3zZsIpOLBkYr9fBcF3HbkKaER5hOBZLfpLgYNw==
+  dependencies:
+    vary "^1.1.2"
+
+"@koa/router@^15.3.0":
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/@koa/router/-/router-15.6.0.tgz#7e13f8828b24102676033b3343e825ef2b5d571b"
+  integrity sha512-iEOXlvGIBqSNkGXrg0XtMARAOm5zA24oedXxiTGEkrD4JgwVjfRDddCQvW1s4WEcwDYvyecRbf8BikXsuEEj8w==
+  dependencies:
+    debug "^4.4.3"
+    http-errors "^2.0.1"
+    koa-compose "^4.1.0"
+    path-to-regexp "^8.4.2"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -755,6 +772,13 @@
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
+"@playwright/browser-chromium@^1.58.2":
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/@playwright/browser-chromium/-/browser-chromium-1.60.0.tgz#2c8ab40e621b13ea4fef195e6e92d0a8cb9a2666"
+  integrity sha512-0ND2pbNWKJYwhlA1LNaDC3DP2x7eguQkQF7Ga7XAlJV0AFieqYNRw/E+gaY9BpSFr1TYwfwXQv1bHq5AK9nbvA==
+  dependencies:
+    playwright-core "1.60.0"
 
 "@prisma/instrumentation@6.19.0":
   version "6.19.0"
@@ -1111,6 +1135,35 @@
     ora "^8.1.0"
     semver "^7.6.2"
 
+"@vscode/test-web@^0.0.80":
+  version "0.0.80"
+  resolved "https://registry.yarnpkg.com/@vscode/test-web/-/test-web-0.0.80.tgz#505f67cd97f3a50b7fa5d311f65be478b70d7b07"
+  integrity sha512-QgsRPp8IuPcdbUdVtqQkFN/sGd+6cr6g0ENEVFOHwJbQqZtJSiZD5w0e6tgmoeq9nBjNqZCq87OO1GkwFHkPyw==
+  dependencies:
+    "@koa/cors" "^5.0.0"
+    "@koa/router" "^15.3.0"
+    "@playwright/browser-chromium" "^1.58.2"
+    gunzip-maybe "^1.4.2"
+    http-proxy-agent "^7.0.2"
+    https-proxy-agent "^7.0.6"
+    koa "^3.1.2"
+    koa-morgan "^1.0.1"
+    koa-mount "^4.2.0"
+    koa-static "^5.0.0"
+    minimist "^1.2.8"
+    playwright "^1.58.2"
+    tar-fs "^3.1.1"
+    tinyglobby "^0.2.15"
+    vscode-uri "^3.1.0"
+
+accepts@^1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
+  integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
+  dependencies:
+    mime-types "~2.1.34"
+    negotiator "0.6.3"
+
 acorn-import-attributes@^1.9.5:
   version "1.9.5"
   resolved "https://registry.yarnpkg.com/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz#7eb1557b1ba05ef18b5ed0ec67591bfab04688ef"
@@ -1234,15 +1287,70 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
+b4a@^1.6.4:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.8.1.tgz#7f16334ca80127aeb26064a28841acbf174840a4"
+  integrity sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+bare-events@^2.5.4, bare-events@^2.7.0:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/bare-events/-/bare-events-2.9.1.tgz#5c86616966343bcb03a1b3155feab253eadbf349"
+  integrity sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==
+
+bare-fs@^4.0.1, bare-fs@^4.5.5:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/bare-fs/-/bare-fs-4.7.2.tgz#0f59b317e5bdbec6a1489b519a06a203cd3fe035"
+  integrity sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==
+  dependencies:
+    bare-events "^2.5.4"
+    bare-path "^3.0.0"
+    bare-stream "^2.6.4"
+    bare-url "^2.2.2"
+    fast-fifo "^1.3.2"
+
+bare-os@^3.0.1:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/bare-os/-/bare-os-3.9.1.tgz#660228ca7ffc47a72e96b6047cdd9d8342994e2f"
+  integrity sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==
+
+bare-path@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/bare-path/-/bare-path-3.0.1.tgz#c12c81b527936b650e87c5d00264d59ef458082c"
+  integrity sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==
+  dependencies:
+    bare-os "^3.0.1"
+
+bare-stream@^2.6.4:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/bare-stream/-/bare-stream-2.13.1.tgz#acfd787a2983f5feb182ffe4c37ecc2c55b6ec85"
+  integrity sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==
+  dependencies:
+    streamx "^2.25.0"
+    teex "^1.0.1"
+
+bare-url@^2.2.2:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/bare-url/-/bare-url-2.4.3.tgz#99aedf87519225669f15ecc0b910db11cad46930"
+  integrity sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==
+  dependencies:
+    bare-path "^3.0.0"
+
 baseline-browser-mapping@^2.9.0:
   version "2.9.19"
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz#3e508c43c46d961eb4d7d2e5b8d1dd0f9ee4f488"
   integrity sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==
+
+basic-auth@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
+  dependencies:
+    safe-buffer "5.1.2"
 
 binary-extensions@^2.0.0:
   version "2.3.0"
@@ -1276,6 +1384,13 @@ browser-stdout@^1.3.1:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
+browserify-zlib@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.1.4.tgz#bb35f8a519f600e0fa6b8485241c979d0141fb2d"
+  integrity sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==
+  dependencies:
+    pako "~0.2.0"
+
 browserslist@^4.24.0:
   version "4.28.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.1.tgz#7f534594628c53c63101079e27e40de490456a95"
@@ -1286,6 +1401,11 @@ browserslist@^4.24.0:
     electron-to-chromium "^1.5.263"
     node-releases "^2.0.27"
     update-browserslist-db "^1.2.0"
+
+buffer-from@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
 c8@^9.1.0:
   version "9.1.0"
@@ -1444,10 +1564,33 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
+content-disposition@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-1.0.1.tgz#a8b7bbeb2904befdfb6787e5c0c086959f605f9b"
+  integrity sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==
+
+content-type@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
+  integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
+
+content-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-2.0.0.tgz#2fb3ede69dffa0af78ca7c4ce7589680638b56df"
+  integrity sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==
+
 convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+cookies@~0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.9.1.tgz#3ffed6f60bb4fb5f146feeedba50acc418af67e3"
+  integrity sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==
+  dependencies:
+    depd "~2.0.0"
+    keygrip "~1.1.0"
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -1501,6 +1644,13 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
+debug@2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
 debug@4, debug@^4.3.5:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
@@ -1508,7 +1658,14 @@ debug@4, debug@^4.3.5:
   dependencies:
     ms "^2.1.3"
 
-debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.1:
+debug@^3.1.0:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.1, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -1519,6 +1676,11 @@ decamelize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
+
+deep-equal@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+  integrity sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -1543,6 +1705,26 @@ define-properties@^1.1.3, define-properties@^1.2.1:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
+delegates@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+  integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
+
+depd@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+  integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
+
+depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
+destroy@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
+  integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
+
 diff@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-7.0.0.tgz#3fb34d387cd76d803f6eebea67b921dab0182a9a"
@@ -1562,10 +1744,25 @@ dunder-proto@^1.0.0, dunder-proto@^1.0.1:
     es-errors "^1.3.0"
     gopd "^1.2.0"
 
+duplexify@^3.5.0, duplexify@^3.6.0:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
+  integrity sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==
+  dependencies:
+    end-of-stream "^1.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+    stream-shift "^1.0.0"
+
 eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
+ee-first@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+  integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.5.263:
   version "1.5.286"
@@ -1586,6 +1783,18 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+encodeurl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
+  integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
+
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.5.tgz#7344d711dea40e0b74abc2ed49778743ccedb08c"
+  integrity sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==
+  dependencies:
+    once "^1.4.0"
 
 enhanced-resolve@^5.15.0:
   version "5.18.2"
@@ -1739,6 +1948,11 @@ escalade@^3.1.1, escalade@^3.2.0:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
+escape-html@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -1841,10 +2055,22 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+events-universal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/events-universal/-/events-universal-1.0.1.tgz#b56a84fd611b6610e0a2d0f09f80fdf931e2dfe6"
+  integrity sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==
+  dependencies:
+    bare-events "^2.7.0"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-fifo@^1.2.0, fast-fifo@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
+  integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
 fast-glob@^3.3.2:
   version "3.3.3"
@@ -1873,6 +2099,11 @@ fastq@^1.6.0:
   integrity sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==
   dependencies:
     reusify "^1.0.4"
+
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
 file-entry-cache@^8.0.0:
   version "8.0.0"
@@ -1933,6 +2164,16 @@ forwarded-parse@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/forwarded-parse/-/forwarded-parse-2.1.2.tgz#08511eddaaa2ddfd56ba11138eee7df117a09325"
   integrity sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==
+
+fresh@~0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+  integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
+
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 fsevents@~2.3.2:
   version "2.3.3"
@@ -2072,6 +2313,18 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+gunzip-maybe@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/gunzip-maybe/-/gunzip-maybe-1.4.2.tgz#b913564ae3be0eda6f3de36464837a9cd94b98ac"
+  integrity sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==
+  dependencies:
+    browserify-zlib "^0.1.4"
+    is-deflate "^1.0.0"
+    is-gzip "^1.0.0"
+    peek-stream "^1.1.0"
+    pumpify "^1.3.3"
+    through2 "^2.0.3"
+
 has-bigints@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.1.0.tgz#28607e965ac967e03cd2a2c70a2636a1edad49fe"
@@ -2135,6 +2388,46 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+http-assert@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/http-assert/-/http-assert-1.5.0.tgz#c389ccd87ac16ed2dfa6246fd73b926aa00e6b8f"
+  integrity sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==
+  dependencies:
+    deep-equal "~1.0.1"
+    http-errors "~1.8.0"
+
+http-errors@^1.7.3, http-errors@~1.8.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
+  integrity sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.1"
+
+http-errors@^2.0.0, http-errors@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"
+  integrity sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==
+  dependencies:
+    depd "~2.0.0"
+    inherits "~2.0.4"
+    setprototypeof "~1.2.0"
+    statuses "~2.0.2"
+    toidentifier "~1.0.1"
+
+http-errors@~1.6.2:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
+  integrity sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
+
 http-proxy-agent@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
@@ -2151,7 +2444,7 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-https-proxy-agent@^7.0.5:
+https-proxy-agent@^7.0.5, https-proxy-agent@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
   integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
@@ -2192,7 +2485,12 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
-inherits@^2.0.3, inherits@~2.0.3:
+inherits@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
+
+inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2290,6 +2588,11 @@ is-date-object@^1.0.5, is-date-object@^1.1.0:
     call-bound "^1.0.2"
     has-tostringtag "^1.0.2"
 
+is-deflate@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-deflate/-/is-deflate-1.0.0.tgz#c862901c3c161fb09dac7cdc7e784f80e98f2f14"
+  integrity sha512-YDoFpuZWu1VRXlsnlYMzKyVRITXj7Ej/V9gXQ2/pAe7X1J7M/RNOqaIYi6qUn+B7nGyB9pDXrv02dsB58d2ZAQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -2323,6 +2626,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-gzip@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-gzip/-/is-gzip-1.0.0.tgz#6ca8b07b99c77998025900e555ced8ed80879a83"
+  integrity sha512-rcfALRIb1YewtnksfRIHGcIY93QnK8BIQ/2c9yDYcG/Y6+vRoJuTWBmmSEbyLLYtXm7q35pHOHbZFQBaLrhlWQ==
 
 is-interactive@^2.0.0:
   version "2.0.0"
@@ -2544,12 +2852,80 @@ jszip@^3.10.1:
     readable-stream "~2.3.6"
     setimmediate "^1.0.5"
 
+keygrip@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.1.0.tgz#871b1681d5e159c62a445b0c74b615e0917e7226"
+  integrity sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==
+  dependencies:
+    tsscmp "1.0.6"
+
 keyv@^4.5.4:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
   integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
   dependencies:
     json-buffer "3.0.1"
+
+koa-compose@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-4.1.0.tgz#507306b9371901db41121c812e923d0d67d3e877"
+  integrity sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==
+
+koa-morgan@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/koa-morgan/-/koa-morgan-1.0.1.tgz#08052e0ce0d839d3c43178b90a5bb3424bef1f99"
+  integrity sha512-JOUdCNlc21G50afBXfErUrr1RKymbgzlrO5KURY+wmDG1Uvd2jmxUJcHgylb/mYXy2SjiNZyYim/ptUBGsIi3A==
+  dependencies:
+    morgan "^1.6.1"
+
+koa-mount@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/koa-mount/-/koa-mount-4.2.0.tgz#66f4436cac76af3075ac432d503299f7678d5914"
+  integrity sha512-2iHQc7vbA9qLeVq5gKAYh3m5DOMMlMfIKjW/REPAS18Mf63daCJHHVXY9nbu7ivrnYn5PiPC4CE523Tf5qvjeQ==
+  dependencies:
+    debug "^4.0.1"
+    koa-compose "^4.1.0"
+
+koa-send@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/koa-send/-/koa-send-5.0.1.tgz#39dceebfafb395d0d60beaffba3a70b4f543fe79"
+  integrity sha512-tmcyQ/wXXuxpDxyNXv5yNNkdAMdFRqwtegBXUaowiQzUKqJehttS0x2j0eOZDQAyloAth5w6wwBImnFzkUz3pQ==
+  dependencies:
+    debug "^4.1.1"
+    http-errors "^1.7.3"
+    resolve-path "^1.4.0"
+
+koa-static@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/koa-static/-/koa-static-5.0.0.tgz#5e92fc96b537ad5219f425319c95b64772776943"
+  integrity sha512-UqyYyH5YEXaJrf9S8E23GoJFQZXkBVJ9zYYMPGz919MSX1KuvAcycIuS0ci150HCoPf4XQVhQ84Qf8xRPWxFaQ==
+  dependencies:
+    debug "^3.1.0"
+    koa-send "^5.0.0"
+
+koa@^3.1.2:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/koa/-/koa-3.2.1.tgz#c99b0c17469418ad5672d3f5832a5610cd6500e4"
+  integrity sha512-e7IpWJrnanNUroVK2taAgMxoEZvHLXdQiNjeExSu/DEIWm83jaKGBgb7tLmu2rMYpA027qFB3iLR/k3AVpFRnA==
+  dependencies:
+    accepts "^1.3.8"
+    content-disposition "~1.0.1"
+    content-type "^1.0.5"
+    cookies "~0.9.1"
+    delegates "^1.0.0"
+    destroy "^1.2.0"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    fresh "~0.5.2"
+    http-assert "^1.5.0"
+    http-errors "^2.0.0"
+    koa-compose "^4.1.0"
+    mime-types "^3.0.1"
+    on-finished "^2.4.1"
+    parseurl "^1.3.3"
+    statuses "^2.0.1"
+    type-is "^2.0.1"
+    vary "^1.1.2"
 
 levn@^0.4.1:
   version "0.4.1"
@@ -2640,6 +3016,11 @@ math-intrinsics@^1.1.0:
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
+media-typer@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-1.1.0.tgz#6ab74b8f2d3320f2064b2a87a38e7931ff3a5561"
+  integrity sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==
+
 memorystream@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
@@ -2657,6 +3038,30 @@ micromatch@^4.0.8:
   dependencies:
     braces "^3.0.3"
     picomatch "^2.3.1"
+
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-db@^1.54.0:
+  version "1.54.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
+  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
+
+mime-types@^3.0.0, mime-types@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-3.0.2.tgz#39002d4182575d5af036ffa118100f2524b2e2ab"
+  integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
+  dependencies:
+    mime-db "^1.54.0"
+
+mime-types@~2.1.34:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mimic-function@^5.0.0:
   version "5.0.1"
@@ -2683,6 +3088,11 @@ minimatch@^9.0.0, minimatch@^9.0.3, minimatch@^9.0.4, minimatch@^9.0.5:
   integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
   dependencies:
     brace-expansion "^2.0.1"
+
+minimist@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 "minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
   version "7.1.2"
@@ -2720,7 +3130,23 @@ module-details-from-path@^1.0.3, module-details-from-path@^1.0.4:
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz#b662fdcd93f6c83d3f25289da0ce81c8d9685b94"
   integrity sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==
 
-ms@^2.1.3:
+morgan@^1.6.1:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.11.0.tgz#98464b8538802f14e9e5374ebe23ac364cd617e8"
+  integrity sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==
+  dependencies:
+    basic-auth "~2.0.1"
+    debug "2.6.9"
+    depd "~2.0.0"
+    on-finished "~2.4.1"
+    on-headers "~1.1.0"
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
+
+ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -2729,6 +3155,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+negotiator@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
+  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -2807,6 +3238,25 @@ object.assign@^4.1.4, object.assign@^4.1.7:
     has-symbols "^1.1.0"
     object-keys "^1.1.1"
 
+on-finished@^2.4.1, on-finished@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
+  integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
+  dependencies:
+    ee-first "1.1.1"
+
+on-headers@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.1.0.tgz#59da4f91c45f5f989c6e4bcedc5a3b0aed70ff65"
+  integrity sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==
+
+once@^1.3.1, once@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+  dependencies:
+    wrappy "1"
+
 onetime@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-7.0.0.tgz#9f16c92d8c9ef5120e3acd9dd9957cceecc1ab60"
@@ -2869,6 +3319,11 @@ package-json-from-dist@^1.0.0:
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
+pako@~0.2.0:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
+  integrity sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==
+
 pako@~1.0.2:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
@@ -2889,10 +3344,20 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parseurl@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
+  integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-is-absolute@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 path-key@^2.0.1:
   version "2.0.1"
@@ -2925,12 +3390,26 @@ path-scurry@^2.0.0:
     lru-cache "^11.0.0"
     minipass "^7.1.2"
 
+path-to-regexp@^8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.4.2.tgz#795c420c4f7ca45c5b887366f622ee0c9852cccd"
+  integrity sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==
+
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
   integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
   dependencies:
     pify "^3.0.0"
+
+peek-stream@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/peek-stream/-/peek-stream-1.1.3.tgz#3b35d84b7ccbbd262fff31dc10da56856ead6d67"
+  integrity sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==
+  dependencies:
+    buffer-from "^1.0.0"
+    duplexify "^3.5.0"
+    through2 "^2.0.3"
 
 pg-int8@1.0.1:
   version "1.0.1"
@@ -2963,6 +3442,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+picomatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+
 pidtree@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
@@ -2972,6 +3456,20 @@ pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==
+
+playwright-core@1.60.0:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.60.0.tgz#24e0d9cc4730713db5dffcace29b5e4696b1907a"
+  integrity sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==
+
+playwright@^1.58.2:
+  version "1.60.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.60.0.tgz#89710863a51f21112633ef8b6b182594d3bfd7b5"
+  integrity sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==
+  dependencies:
+    playwright-core "1.60.0"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 possible-typed-array-names@^1.0.0:
   version "1.1.0"
@@ -3020,6 +3518,31 @@ proxy-from-env@^1.1.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
+pump@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
+  integrity sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pump@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.4.tgz#1f313430527fa8b905622ebd22fe1444e757ab3c"
+  integrity sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pumpify@^1.3.3:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
+  integrity sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==
+  dependencies:
+    duplexify "^3.6.0"
+    inherits "^2.0.3"
+    pump "^2.0.0"
+
 punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
@@ -3046,7 +3569,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@~2.3.6:
+readable-stream@^2.0.0, readable-stream@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
   integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
@@ -3115,6 +3638,14 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
+resolve-path@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/resolve-path/-/resolve-path-1.4.0.tgz#c4bda9f5efb2fce65247873ab36bb4d834fe16f7"
+  integrity sha512-i1xevIst/Qa+nA9olDxLWnLk8YZbi8R/7JPbCMcgyWaFR6bKWaexgJgEB5oc2PKMjYdrHynyz0NY+if+H98t1w==
+  dependencies:
+    http-errors "~1.6.2"
+    path-is-absolute "1.0.1"
+
 resolve@^1.10.0:
   version "1.22.10"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.10.tgz#b663e83ffb09bbf2386944736baae803029b8b39"
@@ -3155,15 +3686,15 @@ safe-array-concat@^1.1.3:
     has-symbols "^1.1.0"
     isarray "^2.0.5"
 
+safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
 safe-buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safe-push-apply@^1.0.0:
   version "1.0.0"
@@ -3244,6 +3775,16 @@ setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
+
+setprototypeof@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
+  integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
+
+setprototypeof@1.2.0, setprototypeof@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
+  integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -3345,6 +3886,16 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz#6d6e980c9df2b6fc905343a3b2d702a6239536c3"
   integrity sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==
 
+"statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+  integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
+statuses@^2.0.1, statuses@~2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
+
 stdin-discarder@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/stdin-discarder/-/stdin-discarder-0.2.2.tgz#390037f44c4ae1a1ae535c5fe38dc3aba8d997be"
@@ -3357,6 +3908,20 @@ stop-iteration-iterator@^1.1.0:
   dependencies:
     es-errors "^1.3.0"
     internal-slot "^1.1.0"
+
+stream-shift@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.3.tgz#85b8fab4d71010fc3ba8772e8046cc49b8a3864b"
+  integrity sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==
+
+streamx@^2.12.5, streamx@^2.15.0, streamx@^2.25.0:
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.26.0.tgz#4d187aaefbed6d499388072a95c846259bc9d335"
+  integrity sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A==
+  dependencies:
+    events-universal "^1.0.0"
+    fast-fifo "^1.3.2"
+    text-decoder "^1.1.0"
 
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
@@ -3510,6 +4075,34 @@ tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.2.tgz#ab4984340d30cb9989a490032f086dbb8b56d872"
   integrity sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==
 
+tar-fs@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-3.1.2.tgz#114b012f54796f31e62f3e57792820a80b83ae6e"
+  integrity sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==
+  dependencies:
+    pump "^3.0.0"
+    tar-stream "^3.1.5"
+  optionalDependencies:
+    bare-fs "^4.0.1"
+    bare-path "^3.0.0"
+
+tar-stream@^3.1.5:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-3.2.0.tgz#0d0064d9b67ea3c9f5abde155e35faab0df37591"
+  integrity sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==
+  dependencies:
+    b4a "^1.6.4"
+    bare-fs "^4.5.5"
+    fast-fifo "^1.2.0"
+    streamx "^2.15.0"
+
+teex@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/teex/-/teex-1.0.1.tgz#b8fa7245ef8e8effa8078281946c85ab780a0b12"
+  integrity sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==
+  dependencies:
+    streamx "^2.12.5"
+
 test-exclude@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
@@ -3519,12 +4112,40 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
+text-decoder@^1.1.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/text-decoder/-/text-decoder-1.2.7.tgz#5d073a9a74b9c0a9d28dfadcab96b604af57d8ba"
+  integrity sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==
+  dependencies:
+    b4a "^1.6.4"
+
+through2@^2.0.3:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
+  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
+  dependencies:
+    readable-stream "~2.3.6"
+    xtend "~4.0.1"
+
+tinyglobby@^0.2.15:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+toidentifier@1.0.1, toidentifier@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -3536,12 +4157,26 @@ ts-api-utils@^2.0.1:
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.4.0.tgz#2690579f96d2790253bdcf1ca35d569ad78f9ad8"
   integrity sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==
 
+tsscmp@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
+  integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-is@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-2.1.0.tgz#71d1a7053293582e16ac9f3ebaf1ab9aa49e5570"
+  integrity sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==
+  dependencies:
+    content-type "^2.0.0"
+    media-typer "^1.1.0"
+    mime-types "^3.0.0"
 
 typed-array-buffer@^1.0.3:
   version "1.0.3"
@@ -3671,6 +4306,16 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+vary@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
+  integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
+
+vscode-uri@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.1.0.tgz#dd09ec5a66a38b5c3fffc774015713496d14e09c"
+  integrity sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==
+
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
@@ -3798,7 +4443,12 @@ wrap-ansi@^8.1.0:
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
 
-xtend@^4.0.0:
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
Add tests for transformers, types, stores, treeview items, and utils. Update esbuild to discover tests recursively from src/ and split extension/test build contexts.