### PR TITLE
feat(types): Support flagpole matches and not_matches operators

### DIFF
--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -122,8 +122,8 @@ suite('types', () => {
   });
 
   suite('OPERATORS', () => {
-    test('contains all six operators', () => {
-      assert.strictEqual(OPERATORS.length, 6);
+    test('contains all eight operators', () => {
+      assert.strictEqual(OPERATORS.length, 8);
     });
 
     test('includes each expected operator', () => {
@@ -133,6 +133,8 @@ suite('types', () => {
       assert.ok(OPERATORS.includes('not_contains'));
       assert.ok(OPERATORS.includes('equals'));
       assert.ok(OPERATORS.includes('not_equals'));
+      assert.ok(OPERATORS.includes('matches'));
+      assert.ok(OPERATORS.includes('not_matches'));
     });
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,19 @@ export type NotEqualsCondition = {
   value: number | string | boolean | number[] | string[];
 };
 
-export type Condition = InCondition | NotInCondition | ContainsCondition | NotContainsCondition | EqualsCondition | NotEqualsCondition;
+export type MatchesCondition = {
+  operator: 'matches';
+  property: PropertyName;
+  value: string[];
+};
+
+export type NotMatchesCondition = {
+  operator: 'not_matches';
+  property: PropertyName;
+  value: string[];
+};
+
+export type Condition = InCondition | NotInCondition | ContainsCondition | NotContainsCondition | EqualsCondition | NotEqualsCondition | MatchesCondition | NotMatchesCondition;
 
 export type OperatorName = Condition['operator'];
 export type PropertyName = 
@@ -122,4 +134,6 @@ export const OPERATORS: OperatorName[] = [
   'not_contains',
   'equals',
   'not_equals',
+  'matches',
+  'not_matches',
 ];


### PR DESCRIPTION
## Summary

Flagpole added two new condition operators, `matches` and `not_matches`, which take a **list of string patterns** where `*` is a wildcard (e.g. `jayonb*`, `*@sentry.io`, `a*b*c`). These are already in use in `sentry-options-automator`'s `flagpole.yaml`, but the extension didn't know about them — so they never appeared in the "Add Condition" operator dropdown and weren't modeled in the `Condition` type.

This adds them as first-class operators (type modeling only — no new editor diagnostics).

## Changes

- **`src/types.ts`** — add `MatchesCondition` / `NotMatchesCondition` types (`value: string[]`), add them to the `Condition` union, and append `'matches'` / `'not_matches'` to `OPERATORS`. `OperatorName` derives from the union automatically, and the "Add Condition" snippet reads `OPERATORS`, so both now show up in its dropdown.
- **`src/types.test.ts`** — update the `OPERATORS` suite (length now 8, plus assertions for the two new operators).

## Flagpole semantics (reference)

From `sentry/src/flagpole/conditions.py`:
- `matches`: a string property matches **any** pattern in the list; `not_matches` is the negation.
- `value` must be a list of strings; `*` is the only special char (zero-or-more of any char, anywhere, case-insensitive — a bespoke matcher, not fnmatch/regex).
- The Evaluate view shells out to the real `flagpole` binary, so there's no JS matcher to reimplement.

## Verification

- `yarn check-types` — clean.
- `yarn test` — 110 passing, including `OPERATORS › contains all eight operators` and `› includes each expected operator`.