### PR TITLE
fix: keep outlines in sync when flagpole.yaml changes in the background

### DIFF
--- a/src/providers/workspaceEventHandlerProvider.ts
+++ b/src/providers/workspaceEventHandlerProvider.ts
@@ -3,6 +3,11 @@ import * as sentryVscode from '../utils/sentryVscode';
 import { addBreadcrumb } from '../utils/sentry';
 import OutlineStore from '../stores/outlineStore';
 
+function isDocumentOpen(uri: vscode.Uri): boolean {
+  const key = uri.toString();
+  return vscode.workspace.textDocuments.some(doc => doc.uri.toString() === key);
+}
+
 export default class WorkspaceEventHandlerProvider {
   public constructor(
     private outlineStore: OutlineStore,
@@ -11,19 +16,74 @@ export default class WorkspaceEventHandlerProvider {
 
   public register(): vscode.Disposable[] {
     return [
-      // We don't care about whether flagpole.yaml is open or not:
-      // sentryVscode.workspace.onDidOpenTextDocument(),
+      // Refresh when a flagpole file is (re)opened, in case its outline was
+      // computed from an older version of the file:
+      sentryVscode.workspace.onDidOpenTextDocument(this.handleDidOpenTextDocument, this),
+      // We don't care about these:
       // sentryVscode.workspace.onDidSaveTextDocument(),
       // sentryVscode.workspace.onDidCloseTextDocument(),
 
       // We do care if flagpole.yaml is changed:
       sentryVscode.workspace.onDidChangeTextDocument(this.handleDidChangeTextDocument, this),
-      
+
       // We do care if the workspace itself is changed:
       sentryVscode.workspace.onDidRenameFiles(this.handleDidRenameFiles, this),
       sentryVscode.workspace.onDidChangeWorkspaceFolders(this.handleDidChangeWorkspaceFolders, this),
+
+      // We do care if flagpole.yaml is changed on disk outside the editor,
+      // e.g. by git pull/rebase/checkout running in the background:
+      ...this.registerFileSystemWatcher(),
     ];
   }
+
+  /**
+   * Watch for flagpole files changing on disk. TextDocument events only fire
+   * for open editors, so without this, background updates (git pull, rebase,
+   * checkout, ...) to closed files would never refresh the outline.
+   */
+  private registerFileSystemWatcher(): vscode.Disposable[] {
+    const pattern = this.documentFilter.pattern;
+    if (!pattern) {
+      return [];
+    }
+
+    const watcher = vscode.workspace.createFileSystemWatcher(pattern);
+
+    const handleDiskChange = (uri: vscode.Uri) => {
+      // Open documents are handled through onDidChangeTextDocument: when the
+      // file is clean VSCode reloads the buffer (firing that event), and when
+      // it is dirty the buffer -- which symbols are computed from -- hasn't
+      // changed. Only closed files need a refresh from here.
+      if (isDocumentOpen(uri)) {
+        return;
+      }
+      addBreadcrumb('Refreshing outline for file changed on disk', 'workspace', 'info', {
+        uri: uri.toString(),
+      });
+      this.outlineStore.fire({uri});
+    };
+
+    return [
+      watcher,
+      watcher.onDidCreate(handleDiskChange),
+      watcher.onDidChange(handleDiskChange),
+      watcher.onDidDelete((uri) => {
+        addBreadcrumb('Forgetting outline for file deleted on disk', 'workspace', 'info', {
+          uri: uri.toString(),
+        });
+        this.outlineStore.forgetOutline(uri);
+      }),
+    ];
+  }
+
+  /**
+   * An event that is emitted when a {@link TextDocument text document} is opened.
+   */
+  handleDidOpenTextDocument = async (document: vscode.TextDocument) => {
+    if (vscode.languages.match(this.documentFilter, document)) {
+      await this.outlineStore.refreshIfStale(document.uri);
+    }
+  };
 
   /**
    * An event that is emitted when a {@link TextDocument text document} is changed. This usually happens

--- a/src/stores/outlineStore.test.ts
+++ b/src/stores/outlineStore.test.ts
@@ -235,3 +235,177 @@ suite('OutlineStore.documentSymbolsToMap', () => {
     assert.ok(result.selectionRange.isEqual(selRange));
   });
 });
+
+function makeOptions(flagName: string, line: number = 0): vscode.DocumentSymbol {
+  const range = new vscode.Range(line, 0, line + 5, 0);
+  const options = new vscode.DocumentSymbol('options', '', vscode.SymbolKind.Property, range, range);
+  const feature = new vscode.DocumentSymbol(flagName, '', vscode.SymbolKind.Property, range, range);
+  feature.children = [
+    makeSymbol('created_at', '2025-01-01'),
+    makeSymbol('owner', 'team-x'),
+  ];
+  options.children = [feature];
+  return options;
+}
+
+type SymbolsResponse = undefined | vscode.DocumentSymbol[];
+
+class FakeSymbolsOutlineStore extends OutlineStore {
+  public fetchCount = 0;
+  public documentVersion: undefined | number = undefined;
+
+  constructor(private responses: Array<() => Promise<SymbolsResponse>>) {
+    super();
+  }
+
+  protected override fetchSymbols(_uri: vscode.Uri): Promise<SymbolsResponse> {
+    const next = this.responses[Math.min(this.fetchCount, this.responses.length - 1)];
+    this.fetchCount += 1;
+    return next();
+  }
+
+  protected override fetchSymbolsOnce(uri: vscode.Uri): Thenable<SymbolsResponse> {
+    return this.fetchSymbols(uri);
+  }
+
+  protected override getDocumentVersion(_uri: vscode.Uri): undefined | number {
+    return this.documentVersion;
+  }
+}
+
+suite('OutlineStore caching', () => {
+  test('getOutline caches by uri value, not object identity', async () => {
+    const store = new FakeSymbolsOutlineStore([
+      () => Promise.resolve([makeOptions('feature.organizations:flag-a')]),
+    ]);
+
+    const outline1 = await store.getOutline(vscode.Uri.parse('file:///test/flagpole.yaml'));
+    const outline2 = await store.getOutline(vscode.Uri.parse('file:///test/flagpole.yaml'));
+    assert.ok(outline1);
+    assert.strictEqual(outline1, outline2);
+    assert.strictEqual(store.fetchCount, 1);
+    store.dispose();
+  });
+
+  test('getOutline recomputes when the document version changes', async () => {
+    const store = new FakeSymbolsOutlineStore([
+      () => Promise.resolve([makeOptions('feature.organizations:flag-a')]),
+      () => Promise.resolve([makeOptions('feature.organizations:flag-b')]),
+    ]);
+    store.documentVersion = 1;
+
+    const outline1 = await store.getOutline(uri);
+    store.documentVersion = 2;
+    const outline2 = await store.getOutline(uri);
+
+    assert.ok(outline1 && outline2);
+    assert.notStrictEqual(outline1, outline2);
+    assert.strictEqual(outline2.map?.allFeatures[0].name, 'feature.organizations:flag-b');
+    assert.strictEqual(store.fetchCount, 2);
+    store.dispose();
+  });
+
+  test('concurrent getOutline calls share one computation', async () => {
+    let resolveSymbols: (value: SymbolsResponse) => void;
+    const store = new FakeSymbolsOutlineStore([
+      () => new Promise(resolve => { resolveSymbols = resolve; }),
+    ]);
+
+    const promise1 = store.getOutline(uri);
+    const promise2 = store.getOutline(uri);
+    resolveSymbols!([makeOptions('feature.organizations:flag-a')]);
+
+    const [outline1, outline2] = await Promise.all([promise1, promise2]);
+    assert.ok(outline1);
+    assert.strictEqual(outline1, outline2);
+    assert.strictEqual(store.fetchCount, 1);
+    store.dispose();
+  });
+
+  test('a slow older computation cannot overwrite a newer one', async () => {
+    let resolveSlow: (value: SymbolsResponse) => void;
+    const store = new FakeSymbolsOutlineStore([
+      () => new Promise(resolve => { resolveSlow = resolve; }),
+      () => Promise.resolve([makeOptions('feature.organizations:flag-new')]),
+    ]);
+
+    const slowFire = store.fire({uri});
+    const fastFire = store.fire({uri});
+    await fastFire;
+    resolveSlow!([makeOptions('feature.organizations:flag-old')]);
+    await slowFire;
+
+    const outline = await store.getOutline(uri);
+    assert.strictEqual(outline?.map?.allFeatures[0].name, 'feature.organizations:flag-new');
+    store.dispose();
+  });
+
+  test('fire only notifies listeners for the newest generation', async () => {
+    let resolveSlow: (value: SymbolsResponse) => void;
+    const store = new FakeSymbolsOutlineStore([
+      () => new Promise(resolve => { resolveSlow = resolve; }),
+      () => Promise.resolve([makeOptions('feature.organizations:flag-new')]),
+    ]);
+    const seen: string[] = [];
+    store.event(outline => {
+      seen.push(outline.map?.allFeatures[0].name ?? '?');
+    });
+
+    const slowFire = store.fire({uri});
+    const fastFire = store.fire({uri});
+    await fastFire;
+    resolveSlow!([makeOptions('feature.organizations:flag-old')]);
+    await slowFire;
+
+    assert.deepStrictEqual(seen, ['feature.organizations:flag-new']);
+    store.dispose();
+  });
+
+  test('forgetOutline drops the cache for equal but distinct Uri instances', async () => {
+    const store = new FakeSymbolsOutlineStore([
+      () => Promise.resolve([makeOptions('feature.organizations:flag-a')]),
+      () => Promise.resolve([makeOptions('feature.organizations:flag-b')]),
+    ]);
+
+    await store.getOutline(vscode.Uri.parse('file:///test/flagpole.yaml'));
+    store.forgetOutline(vscode.Uri.parse('file:///test/flagpole.yaml'));
+    const outline = await store.getOutline(vscode.Uri.parse('file:///test/flagpole.yaml'));
+
+    assert.strictEqual(outline?.map?.allFeatures[0].name, 'feature.organizations:flag-b');
+    assert.strictEqual(store.fetchCount, 2);
+    store.dispose();
+  });
+
+  test('refreshIfStale is a no-op when versions match and refreshes when they differ', async () => {
+    const store = new FakeSymbolsOutlineStore([
+      () => Promise.resolve([makeOptions('feature.organizations:flag-a')]),
+      () => Promise.resolve([makeOptions('feature.organizations:flag-b')]),
+    ]);
+    store.documentVersion = 1;
+
+    await store.fire({uri});
+    await store.refreshIfStale(uri);
+    assert.strictEqual(store.fetchCount, 1);
+
+    store.documentVersion = 2;
+    await store.refreshIfStale(uri);
+    assert.strictEqual(store.fetchCount, 2);
+    const outline = await store.getOutline(uri);
+    assert.strictEqual(outline?.map?.allFeatures[0].name, 'feature.organizations:flag-b');
+    store.dispose();
+  });
+
+  test('knownUris reflects cached outlines', async () => {
+    const store = new FakeSymbolsOutlineStore([
+      () => Promise.resolve([makeOptions('feature.organizations:flag-a')]),
+    ]);
+
+    assert.strictEqual(store.knownUris().length, 0);
+    await store.getOutline(uri);
+    assert.strictEqual(store.knownUris().length, 1);
+    assert.strictEqual(store.knownUris()[0].toString(), uri.toString());
+    store.forgetOutline(uri);
+    assert.strictEqual(store.knownUris().length, 0);
+    store.dispose();
+  });
+});

--- a/src/stores/outlineStore.ts
+++ b/src/stores/outlineStore.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { captureMessage } from '../utils/sentry';
+import { addBreadcrumb, captureMessage } from '../utils/sentry';
 import {
   LogicalCondition,
   LogicalFeature,
@@ -27,9 +27,30 @@ export type Outline = {
   map: SymbolMap,
 };
 
+type CacheEntry = {
+  outline: Outline;
+  // `TextDocument.version` when the outline was computed, or undefined when
+  // the document was not open in any editor at the time.
+  documentVersion: undefined | number;
+};
+
+const SYMBOLS_RETRY_LIMIT_MS = 5_000;
+
+// The YAML language server re-parses asynchronously after a document change,
+// so symbols requested immediately after a change can be computed from the
+// previous content. We re-request after this delay and compare; see
+// scheduleVerification().
+const VERIFY_DELAY_MS = 1_000;
+const VERIFY_MAX_ROUNDS = 3;
+
 export default class OutlineStore extends vscode.EventEmitter<Outline> {
-  private _uris: Map<string, vscode.Uri> = new Map();
-  private _outlineCache: WeakMap<vscode.Uri, Outline> = new WeakMap();
+  // All keys are uri.toString(): vscode.Uri instances are not canonical, and
+  // keying by object identity would let the same file hold multiple,
+  // disagreeing cache entries.
+  private _cache: Map<string, CacheEntry> = new Map();
+  private _pending: Map<string, Promise<undefined | Outline>> = new Map();
+  private _generations: Map<string, number> = new Map();
+  private _verifyTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
 
   protected static documentSymbolsToMap(uri: vscode.Uri, symbols: vscode.DocumentSymbol[]): SymbolMap {
     const optionSymbol = symbols.find(symbol => symbol.name === 'options');
@@ -82,55 +103,194 @@ export default class OutlineStore extends vscode.EventEmitter<Outline> {
 
   /**
    * Fire off an update to this Uri
-   * 
-   * Replaces what's in the cache with a new Outline instance
+   *
+   * Recomputes the Outline and, if this update is still the newest one for
+   * the Uri when the computation finishes, replaces the cache entry and
+   * notifies listeners. Overlapping calls for the same Uri are resolved by a
+   * generation counter so a slow computation from older content can never
+   * overwrite a newer one.
    */
   public async fire({uri}: Pick<Outline, 'uri'>): Promise<void> {
-    this.forgetOutline(uri);
-    const outline = await this.getOutline(uri);
-    if (outline) {
-      super.fire(outline);
+    const key = uri.toString();
+    const generation = (this._generations.get(key) ?? 0) + 1;
+    this._generations.set(key, generation);
+    // In-flight computations were started against older content.
+    this._pending.delete(key);
+    this.clearVerifyTimer(key);
+
+    const outline = await this.computeOutline(uri);
+    if (!outline || this._generations.get(key) !== generation) {
+      return;
     }
+    super.fire(outline);
+    this.scheduleVerification(uri, generation, 0);
+  }
+
+  /**
+   * Recompute only when the cached Outline was built from a different
+   * document version than what is open now. Cheap no-op otherwise.
+   */
+  public async refreshIfStale(uri: vscode.Uri): Promise<void> {
+    const cached = this._cache.get(uri.toString());
+    if (cached && cached.documentVersion === this.getDocumentVersion(uri)) {
+      return;
+    }
+    return this.fire({uri});
   }
 
   public knownUris(): vscode.Uri[] {
-    return Array.from(this._uris.values());
+    return Array.from(this._cache.values(), entry => entry.outline.uri);
   }
 
   /**
-   * Gets an existing cached Outline
+   * Gets the cached Outline, recomputing it when the cache was built from a
+   * different version of the document than what is currently open.
    */
   public async getOutline(uri: vscode.Uri): Promise<undefined | Outline> {
-    if (this._outlineCache.has(uri)) {
-      return this._outlineCache.get(uri);
+    const cached = this._cache.get(uri.toString());
+    if (cached && cached.documentVersion === this.getDocumentVersion(uri)) {
+      return cached.outline;
     }
 
-    const symbols = await getSymbols(uri);
-    if (!symbols) {
-      return undefined;
-    }
-    const map = OutlineStore.documentSymbolsToMap(uri, symbols);
-
-    const outline: Outline = {uri, symbols, map};
-    this._uris.set(uri.fsPath, uri);
-    this._outlineCache.set(uri, outline);
-
-    return outline;
+    return this.computeOutline(uri);
   }
 
   /**
-   * Drops an Outline from the cache
+   * Drops an Outline from the cache and cancels any in-flight computation.
    */
   public forgetOutline(uri: vscode.Uri): void {
-    if (this._outlineCache.has(uri)) {
-      this._uris.delete(uri.fsPath);
-      this._outlineCache.delete(uri);
+    const key = uri.toString();
+    this._generations.set(key, (this._generations.get(key) ?? 0) + 1);
+    this._cache.delete(key);
+    this._pending.delete(key);
+    this.clearVerifyTimer(key);
+  }
+
+  public override dispose(): void {
+    for (const timer of this._verifyTimers.values()) {
+      clearTimeout(timer);
+    }
+    this._verifyTimers.clear();
+    super.dispose();
+  }
+
+  /**
+   * Seam for tests: production behavior polls the document symbol provider.
+   */
+  protected fetchSymbols(uri: vscode.Uri): Promise<undefined | vscode.DocumentSymbol[]> {
+    return getSymbols(uri);
+  }
+
+  /**
+   * Seam for tests: the single-shot request used by the verification pass.
+   */
+  protected fetchSymbolsOnce(uri: vscode.Uri): Thenable<undefined | vscode.DocumentSymbol[]> {
+    return requestSymbols(uri);
+  }
+
+  /**
+   * Seam for tests: production behavior reads the version of the matching
+   * open TextDocument, if any.
+   */
+  protected getDocumentVersion(uri: vscode.Uri): undefined | number {
+    const key = uri.toString();
+    return vscode.workspace.textDocuments.find(doc => doc.uri.toString() === key)?.version;
+  }
+
+  /**
+   * Computes an Outline, deduplicating concurrent requests for the same Uri.
+   * The result is committed to the cache only when no newer update for the
+   * Uri started while the symbols request was in flight.
+   */
+  private computeOutline(uri: vscode.Uri): Promise<undefined | Outline> {
+    const key = uri.toString();
+    const pending = this._pending.get(key);
+    if (pending) {
+      return pending;
+    }
+
+    const generation = this._generations.get(key) ?? 0;
+    // Captured before the request: if the document changes while symbols are
+    // being computed, the entry won't match and will be recomputed on read.
+    const documentVersion = this.getDocumentVersion(uri);
+
+    const promise = this.fetchSymbols(uri).then(symbols => {
+      if (this._pending.get(key) === promise) {
+        this._pending.delete(key);
+      }
+      if (!symbols) {
+        return undefined;
+      }
+      const outline: Outline = {uri, symbols, map: OutlineStore.documentSymbolsToMap(uri, symbols)};
+      if (this._generations.get(key) === generation || this._generations.get(key) === undefined) {
+        this._cache.set(key, {outline, documentVersion});
+      }
+      return outline;
+    });
+    this._pending.set(key, promise);
+    return promise;
+  }
+
+  /**
+   * Re-request symbols after the YAML language server has had time to
+   * re-parse, and correct the cache if the first response was stale.
+   */
+  private scheduleVerification(uri: vscode.Uri, generation: number, round: number): void {
+    if (round >= VERIFY_MAX_ROUNDS) {
+      return;
+    }
+    const key = uri.toString();
+    this.clearVerifyTimer(key);
+    const timer = setTimeout(async () => {
+      this._verifyTimers.delete(key);
+      if (this._generations.get(key) !== generation) {
+        return;
+      }
+      const symbols = await this.fetchSymbolsOnce(uri);
+      if (!symbols || this._generations.get(key) !== generation) {
+        return;
+      }
+      const cached = this._cache.get(key);
+      if (!cached || fingerprintSymbols(cached.outline.symbols) === fingerprintSymbols(symbols)) {
+        return;
+      }
+
+      addBreadcrumb('Corrected stale document symbols', 'outline', 'info', {
+        uri: uri.toString(),
+        round,
+      });
+      const outline: Outline = {uri, symbols, map: OutlineStore.documentSymbolsToMap(uri, symbols)};
+      this._cache.set(key, {outline, documentVersion: this.getDocumentVersion(uri)});
+      super.fire(outline);
+      this.scheduleVerification(uri, generation, round + 1);
+    }, VERIFY_DELAY_MS);
+    this._verifyTimers.set(key, timer);
+  }
+
+  private clearVerifyTimer(key: string): void {
+    const timer = this._verifyTimers.get(key);
+    if (timer) {
+      clearTimeout(timer);
+      this._verifyTimers.delete(key);
     }
   }
 }
 
+function requestSymbols(uri: vscode.Uri): Thenable<undefined | vscode.DocumentSymbol[]> {
+  return vscode.commands.executeCommand<undefined | vscode.DocumentSymbol[]>(
+    'vscode.executeDocumentSymbolProvider',
+    uri
+  );
+}
+
+function fingerprintSymbols(symbols: vscode.DocumentSymbol[]): string {
+  return symbols
+    .map(s => `${s.name}@${s.range.start.line}.${s.range.start.character}-${s.range.end.line}.${s.range.end.character}[${fingerprintSymbols(s.children)}]`)
+    .join(';');
+}
+
 function getSymbols(uri: vscode.Uri, timeout: number = 0): Promise<undefined | vscode.DocumentSymbol[]> {
-  if (timeout > 5_000) {
+  if (timeout > SYMBOLS_RETRY_LIMIT_MS) {
     captureMessage('Timed out waiting for document symbols', 'warning', {
       uri: uri.toString(),
     });
@@ -138,10 +298,7 @@ function getSymbols(uri: vscode.Uri, timeout: number = 0): Promise<undefined | v
   }
   return new Promise(resolve => {
     setTimeout(() => {
-      vscode.commands.executeCommand<undefined | vscode.DocumentSymbol[]>(
-        'vscode.executeDocumentSymbolProvider',
-        uri
-      ).then((symbols) => resolve(symbols ? symbols : getSymbols(uri, timeout + 1_000)));
+      requestSymbols(uri).then((symbols) => resolve(symbols ? symbols : getSymbols(uri, timeout + 1_000)));
     }, timeout);
   });
 }


### PR DESCRIPTION
## Problem

CodeLens, inlay hints, and tree views could show stale, out-of-sync data after `flagpole.yaml` was updated in the background — most commonly by `git pull`/`rebase`/`checkout`. The providers don't read the document text they're handed; they read `OutlineStore`'s cache, so any gap between the buffer and the cache shows up as misplaced lenses and wrong hints until the user edits the file.

Four root causes, each fixed:

### 1. No file-system watcher
`TextDocument` events only fire for open editors. If git rewrote `flagpole.yaml` while it wasn't open, nothing refreshed — the tree views kept the old outline indefinitely, and even reopening the file didn't help (`onDidOpenTextDocument` was commented out).

**Fix:** a `FileSystemWatcher` on the configured flagpole pattern refreshes closed files on create/change and forgets them on delete. Open files are deliberately excluded — they're covered by `onDidChangeTextDocument`, and when the buffer is dirty the on-disk change doesn't affect what symbols are computed from. `onDidOpenTextDocument` is re-enabled and calls the new `refreshIfStale()`, which recomputes only when the cached outline came from a different document version.

### 2. Stale symbols from the YAML extension
`getSymbols()` calls `vscode.executeDocumentSymbolProvider` immediately after a change event, but the YAML language server re-parses asynchronously — the response can be computed from the *previous* content. Stale-but-present symbols were cached and, since the content never changed again, never corrected. This matches the reported symptom exactly.

**Fix:** after each update commits, the store re-requests symbols on a 1s delay and compares a structural fingerprint (names + ranges, recursive). If they differ, it corrects the cache, re-fires listeners, and schedules another verification round (up to 3). A breadcrumb records each correction so we can see in Sentry how often this actually happens.

### 3. Out-of-order async updates
Overlapping `fire()` calls (e.g. several rapid rewrites during a rebase) each ran their own computation, and whichever resolved last won the cache — not necessarily the newest content.

**Fix:** a per-URI generation counter. Each `fire()` bumps the generation; a computation only commits to the cache and notifies listeners if it's still the newest when it finishes.

### 4. Cache keyed by `Uri` object identity
The cache was a `WeakMap<vscode.Uri, Outline>`, but `Uri` instances aren't canonical — `findFiles`, `document.uri`, and a reopened tab all produce different instances for the same path. The same file could hold multiple live, disagreeing cache entries, and `forgetOutline` silently no-oped when handed a different instance.

**Fix:** key everything by `uri.toString()`, and stamp each entry with the `TextDocument.version` it was computed from so `getOutline()` recomputes whenever the buffer has moved on. Concurrent `getOutline()` calls for the same URI now also share one in-flight computation instead of issuing duplicate symbol requests.

## Tests

8 new tests in `outlineStore.test.ts` cover the caching and race behavior via protected test seams (`fetchSymbols`/`getDocumentVersion` overrides): value-keyed caching, version-triggered recompute, request dedup, the slow-old-computation race, listener notification ordering, `forgetOutline` across distinct `Uri` instances, `refreshIfStale`, and `knownUris`.

## Verification

- `yarn check-types`, `yarn lint`, `yarn knip`, `yarn compile` — clean
- `yarn test` — 118 passing (110 existing + 8 new)