### PR TITLE
feat(treeview): Show loading spinner during initial flag parse

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -99,28 +99,32 @@ export function activate(context: vscode.ExtensionContext) {
           vscode.workspace
             .findFiles(flagpoleFileDocumentFilter.pattern, '**/node_modules/**')
             .then(
-              withSentrySync('findFiles.success', (found: vscode.Uri[]) => {
+              withSentrySync('findFiles.success', async (found: vscode.Uri[]) => {
                 addBreadcrumb('Found flagpole files', 'initialization', 'info', {
                   count: found.length,
                 });
-                found.forEach(uri => {
+                await Promise.all(found.map(async uri => {
                   try {
-                    outlineStore.fire({uri});
+                    await outlineStore.fire({uri});
                   } catch (error) {
                     captureException(error as Error, {
                       context: 'outlineStore.fire',
                       uri: uri.toString(),
                     });
                   }
-                });
+                }));
+                outlineStore.markReady();
               }),
               (error: Error) => {
                 captureException(error, {
                   context: 'findFiles',
                   pattern: flagpoleFileDocumentFilter.pattern,
                 });
+                outlineStore.markReady();
               }
             );
+        } else {
+          outlineStore.markReady();
         }
 
         addBreadcrumb('Extension activation completed', 'lifecycle');

--- a/src/providers/flagsByCategoryTreeProvider.ts
+++ b/src/providers/flagsByCategoryTreeProvider.ts
@@ -36,6 +36,7 @@ abstract class FlagsByCategoryTreeProvider implements vscode.TreeDataProvider<Ca
 
   public async getChildren(element?: CategoryTreeViewElement): Promise<CategoryTreeViewElement[]> {
     if (!element) {
+      await this.outlineStore.whenReady();
       return this.outlineStore.knownUris();
     } else if (element instanceof vscode.Uri) {
       const outline = await this.outlineStore.getOutline(element);

--- a/src/providers/flagsByNameTreeViewProvider.ts
+++ b/src/providers/flagsByNameTreeViewProvider.ts
@@ -26,6 +26,7 @@ export default class FlagsByNameTreeViewProvider implements vscode.TreeDataProvi
 
   public async getChildren(element?: TreeViewElement): Promise<TreeViewElement[]> {
     if (!element) {
+      await this.outlineStore.whenReady();
       return this.outlineStore.knownUris();
     } else if (element instanceof vscode.Uri) {
       const outline = await this.outlineStore.getOutline(element);

--- a/src/providers/flagsWithExtraSegmentsTreeViewProvider.ts
+++ b/src/providers/flagsWithExtraSegmentsTreeViewProvider.ts
@@ -26,6 +26,7 @@ export default class FlagsWithExtraSegmentsTreeViewProvider implements vscode.Tr
 
   public async getChildren(element?: TreeViewElement): Promise<TreeViewElement[]> {
     if (!element) {
+      await this.outlineStore.whenReady();
       return this.outlineStore.knownUris();
     } else if (element instanceof vscode.Uri) {
       const outline = await this.outlineStore.getOutline(element);

--- a/src/stores/outlineStore.ts
+++ b/src/stores/outlineStore.ts
@@ -31,6 +31,29 @@ export default class OutlineStore extends vscode.EventEmitter<Outline> {
   private _uris: Map<string, vscode.Uri> = new Map();
   private _outlineCache: WeakMap<vscode.Uri, Outline> = new WeakMap();
 
+  private _initialLoad: Promise<void>;
+  private _resolveReady!: () => void;
+
+  constructor() {
+    super();
+    this._initialLoad = new Promise(resolve => {
+      this._resolveReady = resolve;
+    });
+  }
+
+  /**
+   * Resolves once the initial file scan has completed. Root `getChildren()`
+   * calls await this so VS Code renders its native loading spinner instead of
+   * a blank view while the YAML symbols are still being parsed.
+   */
+  public whenReady(): Promise<void> {
+    return this._initialLoad;
+  }
+
+  public markReady(): void {
+    this._resolveReady();
+  }
+
   protected static documentSymbolsToMap(uri: vscode.Uri, symbols: vscode.DocumentSymbol[]): SymbolMap {
     const optionSymbol = symbols.find(symbol => symbol.name === 'options');
     if (!optionSymbol) {


### PR DESCRIPTION
## Context

The tree views (By Name, By Owner, By Rollout, etc.) "sometimes take a while to initially populate." The genuine cost is parsing `flagpole.yaml` through VS Code's YAML language server (`vscode.executeDocumentSymbolProvider`); that file is large (the extension bumps `yaml.maxItemsComputed` to 10000) so first parse can take seconds.

The reason it *looked frozen*: every provider's root `getChildren()` returned `outlineStore.knownUris()` **synchronously**. During the initial load that array is empty, so VS Code resolved the root instantly with `[]`, rendered a blank view with **no spinner**, and only repainted once parsing finished. That dead-empty window is what reads as "frozen."

## Change

Turn the dead-empty window into VS Code's native tree loading spinner by gating each provider's *root* `getChildren()` on an OutlineStore "ready" signal that stays pending until the initial file scan completes.

- **`src/stores/outlineStore.ts`** — initial-load gate: a promise pending from construction, exposed via `whenReady()` and resolved by `markReady()`.
- **Three tree providers** (`flagsByNameTreeViewProvider`, `flagsWithExtraSegmentsTreeViewProvider`, `flagsByCategoryTreeProvider`) — root `getChildren()` now `await this.outlineStore.whenReady()` before returning URIs. Because the promise stays pending, all six views show a spinner; when it resolves, the same call returns the populated list and paints.
- **`src/extension.ts`** — resolves the gate on every activation path: after all `outlineStore.fire()` calls settle (now awaited via `Promise.all`, preserving per-uri error capture), in the `findFiles` error handler, and immediately when no file pattern is configured (so the "No flagpole.yaml found" welcome still shows).

Edits after load are unaffected — `whenReady()` is already resolved, so `getChildren` returns immediately with no spinner flash.

## Verification

- `yarn run check-types` — clean
- `yarn run lint` — clean
- `yarn test` — all 110 tests pass

Manual: F5 into the Extension Development Host against a repo with a large `flagpole.yaml` and open the Flagpole activity bar on a cold start — each view now spins during parse instead of sitting blank, then populates.