### PR TITLE
fix(transform): Report partial rollout when conditions are truncated

### DIFF
--- a/src/stores/outlineStore.test.ts
+++ b/src/stores/outlineStore.test.ts
@@ -9,6 +9,16 @@ function makeSymbol(name: string, detail: string, children: vscode.DocumentSymbo
   return sym;
 }
 
+// Mirrors the YAML language server's `getDetail`: an array symbol's `detail`
+// is `'[]'` when empty and `undefined` when it has items.
+function makeConditions(children: vscode.DocumentSymbol[] = []): vscode.DocumentSymbol {
+  const detail = children.length ? undefined : '[]';
+  const range = new vscode.Range(0, 0, 0, 0);
+  const sym = new vscode.DocumentSymbol('conditions', detail as unknown as string, vscode.SymbolKind.Array, range, range);
+  sym.children = children;
+  return sym;
+}
+
 const uri = vscode.Uri.parse('file:///test/flagpole.yaml');
 
 class TestableOutlineStore extends OutlineStore {
@@ -52,7 +62,7 @@ suite('OutlineStore.documentSymbolsToMap', () => {
           makeSymbol('0', '', [
             makeSymbol('name', 'GA'),
             makeSymbol('rollout', '100'),
-            makeSymbol('conditions', '', []),
+            makeConditions([]),
           ]),
         ]),
       ]),
@@ -102,7 +112,7 @@ suite('OutlineStore.documentSymbolsToMap', () => {
           makeSymbol('0', '', [
             makeSymbol('name', 'GA'),
             makeSymbol('rollout', '100'),
-            makeSymbol('conditions', '', []),
+            makeConditions([]),
           ]),
         ]),
       ]),
@@ -113,7 +123,7 @@ suite('OutlineStore.documentSymbolsToMap', () => {
           makeSymbol('0', '', [
             makeSymbol('name', 'LA'),
             makeSymbol('rollout', '100'),
-            makeSymbol('conditions', '', [
+            makeConditions([
               makeSymbol('0', '', [
                 makeSymbol('operator', 'in'),
                 makeSymbol('property', 'organization_slug'),
@@ -193,7 +203,7 @@ suite('OutlineStore.documentSymbolsToMap', () => {
           makeSymbol('0', '', [
             makeSymbol('name', 'LA'),
             makeSymbol('rollout', '100'),
-            makeSymbol('conditions', '', [
+            makeConditions([
               makeSymbol('0', '', [
                 makeSymbol('operator', 'in'),
                 makeSymbol('property', 'organization_slug'),
@@ -209,7 +219,7 @@ suite('OutlineStore.documentSymbolsToMap', () => {
           makeSymbol('1', '', [
             makeSymbol('name', 'GA'),
             makeSymbol('rollout', '100'),
-            makeSymbol('conditions', '', []),
+            makeConditions([]),
           ]),
         ]),
       ]),

--- a/src/stores/selectedElementsStore.test.ts
+++ b/src/stores/selectedElementsStore.test.ts
@@ -40,6 +40,7 @@ function makeSegment(name: string, range: vscode.Range): LogicalSegment {
     rollout: 100,
     conditionsSymbol: undefined,
     conditions: [],
+    hasConditions: false,
     rolloutState: '100%',
   };
 }

--- a/src/transform/transformers.test.ts
+++ b/src/transform/transformers.test.ts
@@ -17,6 +17,18 @@ function makeSymbol(name: string, detail: string, children: vscode.DocumentSymbo
   return sym;
 }
 
+// Mirrors the YAML language server's `getDetail`: an array symbol's `detail`
+// is `'[]'` when empty and `undefined` when it has items. The item symbols are
+// also dropped once `yaml.maxItemsComputed` is exhausted, so `detail` — not
+// `children` — is the reliable signal for "has conditions".
+function makeConditions(children: vscode.DocumentSymbol[] = []): vscode.DocumentSymbol {
+  const detail = children.length ? undefined : '[]';
+  const range = new vscode.Range(0, 0, 0, 0);
+  const sym = new vscode.DocumentSymbol('conditions', detail as unknown as string, vscode.SymbolKind.Array, range, range);
+  sym.children = children;
+  return sym;
+}
+
 const uri = vscode.Uri.parse('file:///test/flagpole.yaml');
 
 suite('transformers', () => {
@@ -40,7 +52,7 @@ suite('transformers', () => {
 
   suite('symbolToLogicalCondition', () => {
     test('extracts operator, property, and value detail', () => {
-      const parent = makeSymbol('conditions', '');
+      const parent = makeConditions([]);
       const conditionSymbol = makeSymbol('0', '', [
         makeSymbol('operator', 'in'),
         makeSymbol('property', 'organization_slug'),
@@ -56,7 +68,7 @@ suite('transformers', () => {
     });
 
     test('defaults to empty strings when children are missing', () => {
-      const parent = makeSymbol('conditions', '');
+      const parent = makeConditions([]);
       const conditionSymbol = makeSymbol('0', '', []);
       const result = symbolToLogicalCondition(uri, parent, conditionSymbol);
       assert.strictEqual(result.operator, '');
@@ -65,7 +77,7 @@ suite('transformers', () => {
     });
 
     test('falls back to ["..."] when value detail is empty string', () => {
-      const parent = makeSymbol('conditions', '');
+      const parent = makeConditions([]);
       const conditionSymbol = makeSymbol('0', '', [
         makeSymbol('operator', 'in'),
         makeSymbol('property', 'organization_slug'),
@@ -81,7 +93,7 @@ suite('transformers', () => {
       const symbol = makeSymbol('0', '', [
         makeSymbol('name', 'is_sentry'),
         makeSymbol('rollout', '100'),
-        makeSymbol('conditions', '', [
+        makeConditions([
           makeSymbol('0', '', [
             makeSymbol('operator', 'in'),
             makeSymbol('property', 'organization_slug'),
@@ -100,7 +112,7 @@ suite('transformers', () => {
       const symbol = makeSymbol('0', '', [
         makeSymbol('name', 'GA'),
         makeSymbol('rollout', '100'),
-        makeSymbol('conditions', '', []),
+        makeConditions([]),
       ]);
       const result = symbolToLogicalSegment(uri, symbol);
       assert.strictEqual(result.rolloutState, '100%');
@@ -110,7 +122,7 @@ suite('transformers', () => {
     test('segment with no rollout field and no conditions is 100%', () => {
       const symbol = makeSymbol('0', '', [
         makeSymbol('name', 'GA'),
-        makeSymbol('conditions', '', []),
+        makeConditions([]),
       ]);
       const result = symbolToLogicalSegment(uri, symbol);
       assert.strictEqual(result.rolloutState, '100%');
@@ -120,7 +132,7 @@ suite('transformers', () => {
     test('segment with no rollout field and conditions is partial', () => {
       const symbol = makeSymbol('0', '', [
         makeSymbol('name', 'EA'),
-        makeSymbol('conditions', '', [
+        makeConditions([
           makeSymbol('0', '', [
             makeSymbol('operator', 'equals'),
             makeSymbol('property', 'organization_is-early-adopter'),
@@ -137,7 +149,7 @@ suite('transformers', () => {
       const symbol = makeSymbol('0', '', [
         makeSymbol('name', 'dev'),
         makeSymbol('rollout', '0'),
-        makeSymbol('conditions', '', [
+        makeConditions([
           makeSymbol('0', '', [
             makeSymbol('operator', 'in'),
             makeSymbol('property', 'organization_slug'),
@@ -154,7 +166,7 @@ suite('transformers', () => {
       const symbol = makeSymbol('0', '', [
         makeSymbol('name', 'gradual'),
         makeSymbol('rollout', '50'),
-        makeSymbol('conditions', '', [
+        makeConditions([
           makeSymbol('0', '', [
             makeSymbol('operator', 'in'),
             makeSymbol('property', 'subscription_plan-tier'),
@@ -171,7 +183,7 @@ suite('transformers', () => {
       const symbol = makeSymbol('0', '', [
         makeSymbol('name', 'gradual'),
         makeSymbol('rollout', '50'),
-        makeSymbol('conditions', '', []),
+        makeConditions([]),
       ]);
       const result = symbolToLogicalSegment(uri, symbol);
       assert.strictEqual(result.rolloutState, 'partial');
@@ -189,10 +201,38 @@ suite('transformers', () => {
       assert.strictEqual(result.rolloutState, '100%');
     });
 
+    test('rollout 100 with truncated conditions (no children, detail undefined) is partial', () => {
+      // Reproduces a large flagpole.yaml where the YAML language server hit
+      // `yaml.maxItemsComputed` and dropped the condition items. The
+      // `conditions` key is present with `detail: undefined` (non-empty array),
+      // but `children` is empty.
+      const conditionsSymbol = makeSymbol('conditions', undefined as unknown as string, []);
+      const symbol = makeSymbol('0', '', [
+        makeSymbol('name', 'LA'),
+        makeSymbol('rollout', '100'),
+        conditionsSymbol,
+      ]);
+      const result = symbolToLogicalSegment(uri, symbol);
+      assert.strictEqual(result.conditions.length, 0);
+      assert.strictEqual(result.hasConditions, true);
+      assert.strictEqual(result.rolloutState, 'partial');
+    });
+
+    test('empty conditions (detail "[]") with rollout 100 is 100%', () => {
+      const symbol = makeSymbol('0', '', [
+        makeSymbol('name', 'GA'),
+        makeSymbol('rollout', '100'),
+        makeConditions([]),
+      ]);
+      const result = symbolToLogicalSegment(uri, symbol);
+      assert.strictEqual(result.hasConditions, false);
+      assert.strictEqual(result.rolloutState, '100%');
+    });
+
     test('segment with no name defaults to empty string', () => {
       const symbol = makeSymbol('0', '', [
         makeSymbol('rollout', '100'),
-        makeSymbol('conditions', '', []),
+        makeConditions([]),
       ]);
       const result = symbolToLogicalSegment(uri, symbol);
       assert.strictEqual(result.name, '');
@@ -202,7 +242,7 @@ suite('transformers', () => {
       const symbol = makeSymbol('0', '', [
         makeSymbol('name', 'test'),
         makeSymbol('rollout', '100'),
-        makeSymbol('conditions', '', []),
+        makeConditions([]),
       ]);
       const result = symbolToLogicalSegment(uri, symbol);
       assert.strictEqual(result.uri, uri);
@@ -220,7 +260,7 @@ suite('transformers', () => {
           makeSymbol('0', '', [
             makeSymbol('name', 'IA'),
             makeSymbol('rollout', '100'),
-            makeSymbol('conditions', '', [
+            makeConditions([
               makeSymbol('0', '', [
                 makeSymbol('operator', 'in'),
                 makeSymbol('property', 'organization_slug'),
@@ -240,6 +280,29 @@ suite('transformers', () => {
       assert.strictEqual(result.hasExtraSegments, false);
     });
 
+    test('feature with rollout-100 segment whose conditions were truncated is partial', () => {
+      // A large file where the YAML language server dropped the condition
+      // items: the segment reports rollout 100 with an empty (truncated)
+      // conditions list, which previously mis-read as 100%.
+      const symbol = makeSymbol('feature.organizations:issue-performance-n-plus-one-db-queries-experimental-visible', '', [
+        makeSymbol('created_at', '2025-05-09'),
+        makeSymbol('enabled', 'true'),
+        makeSymbol('owner', '', [makeSymbol('team', 'issue_detection')]),
+        makeSymbol('segments', '', [
+          makeSymbol('0', '', [
+            makeSymbol('name', 'LA'),
+            makeSymbol('rollout', '100'),
+            makeSymbol('conditions', undefined as unknown as string, []),
+          ]),
+        ]),
+      ]);
+      const result = symbolToLogicalFeature(uri, symbol);
+      assert.strictEqual(result.rolloutState, 'partial');
+      assert.strictEqual(result.segments.length, 1);
+      assert.strictEqual(result.segments[0].hasConditions, true);
+      assert.strictEqual(result.hasExtraSegments, false);
+    });
+
     test('feature with 100% segment becomes 100%', () => {
       const symbol = makeSymbol('feature.organizations:full-rollout', '', [
         makeSymbol('created_at', '2025-01-01'),
@@ -249,7 +312,7 @@ suite('transformers', () => {
           makeSymbol('0', '', [
             makeSymbol('name', 'GA'),
             makeSymbol('rollout', '100'),
-            makeSymbol('conditions', '', []),
+            makeConditions([]),
           ]),
         ]),
       ]);
@@ -267,12 +330,12 @@ suite('transformers', () => {
           makeSymbol('0', '', [
             makeSymbol('name', 'GA'),
             makeSymbol('rollout', '100'),
-            makeSymbol('conditions', '', []),
+            makeConditions([]),
           ]),
           makeSymbol('1', '', [
             makeSymbol('name', 'LA'),
             makeSymbol('rollout', '100'),
-            makeSymbol('conditions', '', [
+            makeConditions([
               makeSymbol('0', '', [
                 makeSymbol('operator', 'in'),
                 makeSymbol('property', 'organization_slug'),
@@ -296,7 +359,7 @@ suite('transformers', () => {
           makeSymbol('0', '', [
             makeSymbol('name', 'GA'),
             makeSymbol('rollout', '0'),
-            makeSymbol('conditions', '', []),
+            makeConditions([]),
           ]),
         ]),
       ]);
@@ -335,7 +398,7 @@ suite('transformers', () => {
           makeSymbol('0', '', [
             makeSymbol('name', 'LA'),
             makeSymbol('rollout', '100'),
-            makeSymbol('conditions', '', [
+            makeConditions([
               makeSymbol('0', '', [
                 makeSymbol('operator', 'in'),
                 makeSymbol('property', 'organization_slug'),
@@ -408,7 +471,7 @@ suite('transformers', () => {
           makeSymbol('0', '', [
             makeSymbol('name', 'LA'),
             makeSymbol('rollout', '100'),
-            makeSymbol('conditions', '', [
+            makeConditions([
               makeSymbol('0', '', [
                 makeSymbol('operator', 'in'),
                 makeSymbol('property', 'organization_slug'),
@@ -419,7 +482,7 @@ suite('transformers', () => {
           makeSymbol('1', '', [
             makeSymbol('name', 'EA'),
             makeSymbol('rollout', '0'),
-            makeSymbol('conditions', '', []),
+            makeConditions([]),
           ]),
         ]),
       ]);
@@ -436,7 +499,7 @@ suite('transformers', () => {
           makeSymbol('0', '', [
             makeSymbol('name', 'LA'),
             makeSymbol('rollout', '100'),
-            makeSymbol('conditions', '', [
+            makeConditions([
               makeSymbol('0', '', [
                 makeSymbol('operator', 'in'),
                 makeSymbol('property', 'organization_slug'),
@@ -447,7 +510,7 @@ suite('transformers', () => {
           makeSymbol('1', '', [
             makeSymbol('name', 'GA'),
             makeSymbol('rollout', '100'),
-            makeSymbol('conditions', '', []),
+            makeConditions([]),
           ]),
         ]),
       ]);
@@ -465,7 +528,7 @@ suite('transformers', () => {
         ownerSymbol,
         makeSymbol('segments', '', [
           makeSymbol('0', '', [
-            makeSymbol('conditions', '', []),
+            makeConditions([]),
             makeSymbol('name', 'GA'),
             makeSymbol('rollout', '50'),
           ]),
@@ -523,6 +586,7 @@ suite('transformers', () => {
         rollout: 100,
         conditionsSymbol: undefined,
         conditions: [],
+        hasConditions: false,
         rolloutState: '100%',
         ...overrides,
       };

--- a/src/transform/transformers.ts
+++ b/src/transform/transformers.ts
@@ -35,6 +35,7 @@ export type LogicalSegment = {
   rollout: number;
   conditionsSymbol: vscode.DocumentSymbol | undefined,
   conditions: LogicalCondition[];
+  hasConditions: boolean;
   rolloutState: RolloutState;
 };
 
@@ -85,7 +86,7 @@ export function symbolToLogicalFeature(uri: vscode.Uri, symbol: vscode.DocumentS
     return prev;
   }, '0%' as RolloutState);
 
-  const hasExtraSegments = (rolloutState === '100%') ?(segments.at(-1)?.conditions.length ?? 0) > 0 : false;
+  const hasExtraSegments = (rolloutState === '100%') ? (segments.at(-1)?.hasConditions ?? false) : false;
 
   let ownerValue = owner?.detail ?? '';
   if (!ownerValue && owner?.children?.length) {
@@ -114,13 +115,21 @@ export function symbolToLogicalSegment(uri: vscode.Uri, symbol: vscode.DocumentS
   const conditionsSymbol = symbol.children.find(child => child.name === 'conditions');
   const conditions = conditionsSymbol?.children.map(symbol => symbolToLogicalCondition(uri, conditionsSymbol, symbol)) ?? [];
 
+  // The YAML language server truncates the symbol tree once
+  // `yaml.maxItemsComputed` is reached, dropping the `conditions` array items
+  // on large files even though the `conditions` key itself is present. Its
+  // `detail` still reflects the real array: `'[]'` for a genuinely empty
+  // array, `undefined` when it has items. Trust `detail`, not `children`,
+  // which may have been truncated to empty.
+  const hasConditions = conditionsSymbol !== undefined && conditionsSymbol.detail !== '[]';
+
   const rolloutState = (function() {
     if (rollout?.detail === '0') {
       return '0%';
     }
     // If `rollout` is not specified it's defaulted to 100
     // Or if there are no conditions, it's also out to 100
-    if ([undefined, '100'].includes(rollout?.detail) && conditions?.length === 0) {
+    if ([undefined, '100'].includes(rollout?.detail) && !hasConditions) {
       return '100%';
     }
     return 'partial' as const;
@@ -133,6 +142,7 @@ export function symbolToLogicalSegment(uri: vscode.Uri, symbol: vscode.DocumentS
     rollout: Number(rollout?.detail ?? 100), // default to 100 if omitted
     conditionsSymbol,
     conditions,
+    hasConditions,
     rolloutState,
   };
 }


### PR DESCRIPTION
## Problem

Flags showed **100% rolled out** when they clearly weren't. Example — a flag with a single segment that has conditions should read **partial**, but showed 100%:

```yaml
feature.organizations:issue-performance-n-plus-one-db-queries-experimental-visible:
  enabled: true
  segments:
    - conditions:
        - operator: in
          property: organization_slug
          value: [sentry, codecov, ...]
      name: LA
      rollout: 100
```

The bug was **file-size dependent** (intermittent) — small files were fine, large ones were wrong.

## Root cause

The rollout logic was correct; the data feeding it was truncated.

The redhat YAML language server builds its `DocumentSymbol` tree **breadth-first under a shared item budget** (`yaml.maxItemsComputed`, set to `10000`). On a large `flagpole.yaml`, that budget is exhausted before the traversal reaches the deeply-nested `conditions` *items*. The `conditions` symbol is still present, but its `children` array comes back **empty**.

The segment classifier keyed off `conditions.length === 0`, so a truncated conditions list looked identical to "no conditions":

```ts
if ([undefined, '100'].includes(rollout?.detail) && conditions?.length === 0) {
  return '100%'; // ← wrong when conditions were truncated, not absent
}
```

## Fix

The language server's `getDetail` sets an array symbol's `detail` to `'[]'` when genuinely empty and `undefined` when it has items — and `detail` reflects the real AST **even when the children are truncated**. Derive "has conditions" from `detail` instead of `children.length`:

```ts
const hasConditions = conditionsSymbol !== undefined && conditionsSymbol.detail !== '[]';
```

Applied to both the segment `rolloutState` and `hasExtraSegments` (which had the same latent bug).

## Tests

- Added regression tests reproducing the truncated-conditions shape at both segment and feature level (including the exact flag above).
- Updated the symbol fixtures across the affected test files to mirror the language server's real `getDetail` output instead of the previously-inaccurate empty-string detail.
- `check-types` ✅ · `lint` ✅ · **121 tests passing** ✅