### PR TITLE
fix(treeview): Parse flagpole.yaml ourselves to fix truncated rollout state

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -4,6 +4,11 @@ const path = require('path');
 const copyStaticFiles = require('esbuild-copy-static-files');
 const { sentryEsbuildPlugin } = require("@sentry/esbuild-plugin");
 
+// This is a web extension: `main`/`browser` both point at one bundle that runs
+// in VS Code's browser worker. `yaml`'s Node build does `require('process')`,
+// which throws there, so pull in its `process`-free browser build instead.
+const yamlBrowserBuild = path.resolve(__dirname, 'node_modules/yaml/browser/index.js');
+
 
 const production = process.argv.includes('--production');
 const watch = process.argv.includes('--watch');
@@ -16,6 +21,7 @@ async function main() {
     sourcemap: production ? 'external' : false,
     sourcesContent: false,
     platform: 'node',
+    alias: { yaml: yamlBrowserBuild },
     outdir: 'dist/',
     logLevel: 'warning',
   };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
       "files.associations": {
         "flagpole.yaml": "yaml"
       },
-      "yaml.maxItemsComputed": 10000
+      "yaml.maxItemsComputed": 50000
     },
     "configuration": {
       "title": "Flagpole Explorer",
@@ -193,7 +193,8 @@
   },
   "dependencies": {
     "@sentry/node": "10.32.1",
-    "glob": "13.0.0"
+    "glob": "13.0.0",
+    "yaml": "2.9.0"
   },
   "devDependencies": {
     "@sentry/esbuild-plugin": "4.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       glob:
         specifier: 10.5.0
         version: 10.5.0
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
     devDependencies:
       '@sentry/esbuild-plugin':
         specifier: 4.9.0

--- a/src/stores/outlineStore.test.ts
+++ b/src/stores/outlineStore.test.ts
@@ -274,10 +274,6 @@ class FakeSymbolsOutlineStore extends OutlineStore {
     return next();
   }
 
-  protected override fetchSymbolsOnce(uri: vscode.Uri): Thenable<SymbolsResponse> {
-    return this.fetchSymbols(uri);
-  }
-
   protected override getDocumentVersion(_uri: vscode.Uri): undefined | number {
     return this.documentVersion;
   }

--- a/src/stores/outlineStore.ts
+++ b/src/stores/outlineStore.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { addBreadcrumb, captureMessage } from '../utils/sentry';
+import parseFlagpoleSymbols from '../transform/parseFlagpoleSymbols';
 import {
   LogicalCondition,
   LogicalFeature,
@@ -23,7 +23,6 @@ type SymbolMap = undefined | {
 
 export type Outline = {
   uri: vscode.Uri,
-  symbols: vscode.DocumentSymbol[],
   map: SymbolMap,
 };
 
@@ -34,15 +33,6 @@ type CacheEntry = {
   documentVersion: undefined | number;
 };
 
-const SYMBOLS_RETRY_LIMIT_MS = 5_000;
-
-// The YAML language server re-parses asynchronously after a document change,
-// so symbols requested immediately after a change can be computed from the
-// previous content. We re-request after this delay and compare; see
-// scheduleVerification().
-const VERIFY_DELAY_MS = 1_000;
-const VERIFY_MAX_ROUNDS = 3;
-
 export default class OutlineStore extends vscode.EventEmitter<Outline> {
   // All keys are uri.toString(): vscode.Uri instances are not canonical, and
   // keying by object identity would let the same file hold multiple,
@@ -50,7 +40,6 @@ export default class OutlineStore extends vscode.EventEmitter<Outline> {
   private _cache: Map<string, CacheEntry> = new Map();
   private _pending: Map<string, Promise<undefined | Outline>> = new Map();
   private _generations: Map<string, number> = new Map();
-  private _verifyTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
 
   private _initialLoad: Promise<void>;
   private _resolveReady!: () => void;
@@ -139,14 +128,12 @@ export default class OutlineStore extends vscode.EventEmitter<Outline> {
     this._generations.set(key, generation);
     // In-flight computations were started against older content.
     this._pending.delete(key);
-    this.clearVerifyTimer(key);
 
     const outline = await this.computeOutline(uri);
     if (!outline || this._generations.get(key) !== generation) {
       return;
     }
     super.fire(outline);
-    this.scheduleVerification(uri, generation, 0);
   }
 
   /**
@@ -186,29 +173,13 @@ export default class OutlineStore extends vscode.EventEmitter<Outline> {
     this._generations.set(key, (this._generations.get(key) ?? 0) + 1);
     this._cache.delete(key);
     this._pending.delete(key);
-    this.clearVerifyTimer(key);
-  }
-
-  public override dispose(): void {
-    for (const timer of this._verifyTimers.values()) {
-      clearTimeout(timer);
-    }
-    this._verifyTimers.clear();
-    super.dispose();
   }
 
   /**
-   * Seam for tests: production behavior polls the document symbol provider.
+   * Seam for tests: production behavior parses the document text ourselves.
    */
   protected fetchSymbols(uri: vscode.Uri): Promise<undefined | vscode.DocumentSymbol[]> {
-    return getSymbols(uri);
-  }
-
-  /**
-   * Seam for tests: the single-shot request used by the verification pass.
-   */
-  protected fetchSymbolsOnce(uri: vscode.Uri): Thenable<undefined | vscode.DocumentSymbol[]> {
-    return requestSymbols(uri);
+    return parseSymbols(uri);
   }
 
   /**
@@ -244,7 +215,7 @@ export default class OutlineStore extends vscode.EventEmitter<Outline> {
       if (!symbols) {
         return undefined;
       }
-      const outline: Outline = {uri, symbols, map: OutlineStore.documentSymbolsToMap(uri, symbols)};
+      const outline: Outline = {uri, map: OutlineStore.documentSymbolsToMap(uri, symbols)};
       if (this._generations.get(key) === generation || this._generations.get(key) === undefined) {
         this._cache.set(key, {outline, documentVersion});
       }
@@ -253,75 +224,9 @@ export default class OutlineStore extends vscode.EventEmitter<Outline> {
     this._pending.set(key, promise);
     return promise;
   }
-
-  /**
-   * Re-request symbols after the YAML language server has had time to
-   * re-parse, and correct the cache if the first response was stale.
-   */
-  private scheduleVerification(uri: vscode.Uri, generation: number, round: number): void {
-    if (round >= VERIFY_MAX_ROUNDS) {
-      return;
-    }
-    const key = uri.toString();
-    this.clearVerifyTimer(key);
-    const timer = setTimeout(async () => {
-      this._verifyTimers.delete(key);
-      if (this._generations.get(key) !== generation) {
-        return;
-      }
-      const symbols = await this.fetchSymbolsOnce(uri);
-      if (!symbols || this._generations.get(key) !== generation) {
-        return;
-      }
-      const cached = this._cache.get(key);
-      if (!cached || fingerprintSymbols(cached.outline.symbols) === fingerprintSymbols(symbols)) {
-        return;
-      }
-
-      addBreadcrumb('Corrected stale document symbols', 'outline', 'info', {
-        uri: uri.toString(),
-        round,
-      });
-      const outline: Outline = {uri, symbols, map: OutlineStore.documentSymbolsToMap(uri, symbols)};
-      this._cache.set(key, {outline, documentVersion: this.getDocumentVersion(uri)});
-      super.fire(outline);
-      this.scheduleVerification(uri, generation, round + 1);
-    }, VERIFY_DELAY_MS);
-    this._verifyTimers.set(key, timer);
-  }
-
-  private clearVerifyTimer(key: string): void {
-    const timer = this._verifyTimers.get(key);
-    if (timer) {
-      clearTimeout(timer);
-      this._verifyTimers.delete(key);
-    }
-  }
 }
 
-function requestSymbols(uri: vscode.Uri): Thenable<undefined | vscode.DocumentSymbol[]> {
-  return vscode.commands.executeCommand<undefined | vscode.DocumentSymbol[]>(
-    'vscode.executeDocumentSymbolProvider',
-    uri
-  );
-}
-
-function fingerprintSymbols(symbols: vscode.DocumentSymbol[]): string {
-  return symbols
-    .map(s => `${s.name}@${s.range.start.line}.${s.range.start.character}-${s.range.end.line}.${s.range.end.character}[${fingerprintSymbols(s.children)}]`)
-    .join(';');
-}
-
-function getSymbols(uri: vscode.Uri, timeout: number = 0): Promise<undefined | vscode.DocumentSymbol[]> {
-  if (timeout > SYMBOLS_RETRY_LIMIT_MS) {
-    captureMessage('Timed out waiting for document symbols', 'warning', {
-      uri: uri.toString(),
-    });
-    return Promise.resolve(undefined);
-  }
-  return new Promise(resolve => {
-    setTimeout(() => {
-      requestSymbols(uri).then((symbols) => resolve(symbols ? symbols : getSymbols(uri, timeout + 1_000)));
-    }, timeout);
-  });
+async function parseSymbols(uri: vscode.Uri): Promise<undefined | vscode.DocumentSymbol[]> {
+  const document = await vscode.workspace.openTextDocument(uri);
+  return parseFlagpoleSymbols(document);
 }

--- a/src/transform/parseFlagpoleSymbols.test.ts
+++ b/src/transform/parseFlagpoleSymbols.test.ts
@@ -1,0 +1,279 @@
+import * as assert from '../test-utils/assert';
+import * as vscode from 'vscode';
+import parseFlagpoleSymbols from './parseFlagpoleSymbols';
+import { symbolToLogicalFeature } from './transformers';
+
+async function parse(content: string): Promise<vscode.DocumentSymbol[]> {
+  const document = await vscode.workspace.openTextDocument({ content, language: 'yaml' });
+  return parseFlagpoleSymbols(document);
+}
+
+function findChild(symbols: vscode.DocumentSymbol[], name: string): vscode.DocumentSymbol | undefined {
+  return symbols.find(symbol => symbol.name === name);
+}
+
+async function firstFeature(content: string) {
+  const symbols = await parse(content);
+  const options = findChild(symbols, 'options');
+  assert.ok(options, 'expected an options symbol');
+  const featureSymbol = options.children[0];
+  assert.ok(featureSymbol, 'expected at least one feature');
+  return symbolToLogicalFeature(vscode.Uri.parse('file:///test/flagpole.yaml'), featureSymbol);
+}
+
+suite('parseFlagpoleSymbols', () => {
+  test('segment with rollout 100 and a condition is partial', async () => {
+    const feature = await firstFeature(`options:
+  feature.organizations:sentry-apps-claude-routine-webhooks:
+    created_at: "2026-07-13"
+    enabled: true
+    owner:
+      team: issue_detection
+    segments:
+      - name: Sentry
+        rollout: 100
+        conditions:
+          - operator: in
+            property: organization_slug
+            value:
+              - sentry
+              - charlie-test
+`);
+    assert.strictEqual(feature.name, 'feature.organizations:sentry-apps-claude-routine-webhooks');
+    assert.strictEqual(feature.created_at, '2026-07-13');
+    assert.strictEqual(feature.enabled, true);
+    assert.strictEqual(feature.owner, 'issue_detection');
+    assert.strictEqual(feature.rolloutState, 'partial');
+    assert.strictEqual(feature.segments.length, 1);
+    assert.strictEqual(feature.segments[0].rollout, 100);
+    assert.strictEqual(feature.segments[0].hasConditions, true);
+    assert.strictEqual(feature.segments[0].conditions.length, 1);
+    const condition = feature.segments[0].conditions[0];
+    assert.strictEqual(condition.operator, 'in');
+    assert.strictEqual(condition.property, 'organization_slug');
+    assert.deepStrictEqual(condition.value, ['sentry', 'charlie-test']);
+  });
+
+  test('segment with rollout 100 and empty conditions is 100%', async () => {
+    const feature = await firstFeature(`options:
+  feature.organizations:ga:
+    created_at: "2025-01-01"
+    enabled: true
+    owner: team-x
+    segments:
+      - name: GA
+        rollout: 100
+        conditions: []
+`);
+    assert.strictEqual(feature.rolloutState, '100%');
+    assert.strictEqual(feature.segments[0].hasConditions, false);
+  });
+
+  test('segment with omitted rollout and no conditions is 100%', async () => {
+    const feature = await firstFeature(`options:
+  feature.organizations:ga:
+    created_at: "2025-01-01"
+    enabled: true
+    owner: team-x
+    segments:
+      - name: GA
+        conditions: []
+`);
+    assert.strictEqual(feature.rolloutState, '100%');
+    assert.strictEqual(feature.segments[0].rollout, 100);
+  });
+
+  test('segment with rollout 0 is 0%', async () => {
+    const feature = await firstFeature(`options:
+  feature.organizations:off:
+    created_at: "2025-01-01"
+    enabled: true
+    owner: team-x
+    segments:
+      - name: dev
+        rollout: 0
+`);
+    assert.strictEqual(feature.rolloutState, '0%');
+  });
+
+  test('100% wins over partial, and a conditioned last segment is an extra segment', async () => {
+    const feature = await firstFeature(`options:
+  feature.organizations:mixed:
+    created_at: "2025-01-01"
+    enabled: true
+    owner: team-x
+    segments:
+      - name: GA
+        rollout: 100
+        conditions: []
+      - name: LA
+        rollout: 100
+        conditions:
+          - operator: in
+            property: organization_slug
+            value:
+              - sentry
+`);
+    assert.strictEqual(feature.rolloutState, '100%');
+    assert.strictEqual(feature.hasExtraSegments, true);
+  });
+
+  test('partial wins when no segment is fully rolled out', async () => {
+    const feature = await firstFeature(`options:
+  feature.organizations:multi:
+    created_at: "2025-01-01"
+    enabled: true
+    owner: team-x
+    segments:
+      - name: LA
+        rollout: 100
+        conditions:
+          - operator: in
+            property: organization_slug
+            value:
+              - sentry
+      - name: EA
+        rollout: 0
+        conditions: []
+`);
+    assert.strictEqual(feature.rolloutState, 'partial');
+  });
+
+  test('owner as a team map and as a scalar shorthand both resolve', async () => {
+    const symbols = await parse(`options:
+  feature.organizations:team-map:
+    created_at: "2025-01-01"
+    owner:
+      team: issue_detection
+  feature.organizations:team-scalar:
+    created_at: "2025-01-01"
+    owner: alerts-notifications
+`);
+    const options = findChild(symbols, 'options');
+    assert.ok(options);
+    const uri = vscode.Uri.parse('file:///test/flagpole.yaml');
+    const mapFeature = symbolToLogicalFeature(uri, options.children[0]);
+    const scalarFeature = symbolToLogicalFeature(uri, options.children[1]);
+    assert.strictEqual(mapFeature.owner, 'issue_detection');
+    assert.strictEqual(scalarFeature.owner, 'alerts-notifications');
+  });
+
+  test('enabled: false is detected', async () => {
+    const feature = await firstFeature(`options:
+  feature.organizations:disabled:
+    created_at: "2026-02-23"
+    enabled: false
+    owner: team-x
+    segments:
+      - name: LA
+        rollout: 100
+        conditions:
+          - operator: in
+            property: organization_slug
+            value:
+              - sentry
+`);
+    assert.strictEqual(feature.enabled, false);
+  });
+
+  test('symbol ranges point at the source location', async () => {
+    const content = `options:
+  feature.organizations:first:
+    created_at: "2025-01-01"
+    owner: team-x
+  feature.organizations:second:
+    created_at: "2025-01-02"
+    owner: team-y
+`;
+    const symbols = await parse(content);
+    const options = findChild(symbols, 'options');
+    assert.ok(options);
+    const second = options.children[1];
+    assert.strictEqual(second.name, 'feature.organizations:second');
+    // The `feature.organizations:second` key is on the 5th line (0-indexed 4).
+    assert.strictEqual(second.selectionRange.start.line, 4);
+    assert.strictEqual(second.selectionRange.start.character, 2);
+  });
+
+  test('returns an empty tree for an empty document', async () => {
+    const symbols = await parse('');
+    assert.deepStrictEqual(symbols, []);
+  });
+
+  test('condition value sequence reports having items via detail', async () => {
+    const symbols = await parse(`options:
+  feature.organizations:cond:
+    segments:
+      - name: LA
+        rollout: 100
+        conditions:
+          - operator: in
+            property: organization_slug
+            value:
+              - sentry
+`);
+    const options = findChild(symbols, 'options');
+    const feature = findChild(options!.children, 'feature.organizations:cond');
+    const segments = findChild(feature!.children, 'segments');
+    const conditions = findChild(segments!.children[0].children, 'conditions');
+    assert.ok(conditions);
+    assert.strictEqual(conditions.detail as unknown, undefined);
+    assert.strictEqual(conditions.children.length, 1);
+  });
+
+  test('reads a scalar condition value', async () => {
+    const feature = await firstFeature(`options:
+  feature.organizations:scalar-value:
+    segments:
+      - name: EA
+        conditions:
+          - operator: equals
+            property: organization_is-early-adopter
+            value: true
+`);
+    assert.deepStrictEqual(feature.segments[0].conditions[0].value, 'true');
+  });
+
+  test('resolves an aliased condition value list', async () => {
+    const feature = await firstFeature(`_anchors:
+  single_tenants: &_single_tenants
+    - us
+    - de
+options:
+  feature.organizations:aliased-value:
+    segments:
+      - name: GA
+        rollout: 100
+        conditions:
+          - operator: not_in
+            property: sentry_region
+            value: *_single_tenants
+`);
+    assert.strictEqual(feature.rolloutState, 'partial');
+    assert.deepStrictEqual(feature.segments[0].conditions[0].value, ['us', 'de']);
+  });
+
+  test('resolves an aliased segment so its conditions are seen', async () => {
+    // An aliased segment whose anchor is rollout 100 *with* a condition must
+    // read as partial, not as a bare 100% segment.
+    const feature = await firstFeature(`_anchors:
+  closed_beta: &_closed_beta
+    name: Closed Beta
+    rollout: 100
+    conditions:
+      - operator: in
+        property: organization_slug
+        value:
+          - sentry
+options:
+  feature.organizations:aliased-segment:
+    segments:
+      - *_closed_beta
+`);
+    assert.strictEqual(feature.rolloutState, 'partial');
+    assert.strictEqual(feature.segments.length, 1);
+    assert.strictEqual(feature.segments[0].rollout, 100);
+    assert.strictEqual(feature.segments[0].hasConditions, true);
+    assert.deepStrictEqual(feature.segments[0].conditions[0].value, ['sentry']);
+  });
+});

--- a/src/transform/parseFlagpoleSymbols.ts
+++ b/src/transform/parseFlagpoleSymbols.ts
@@ -1,0 +1,142 @@
+import * as vscode from 'vscode';
+import { Document, isAlias, isMap, isNode, isScalar, isSeq, Node, parseDocument, Scalar, YAMLMap, YAMLSeq } from 'yaml';
+
+/**
+ * Builds the `DocumentSymbol` tree for a flagpole.yaml document by parsing the
+ * text ourselves rather than asking `vscode.executeDocumentSymbolProvider`.
+ *
+ * The YAML language server truncates its symbol tree once `yaml.maxItemsComputed`
+ * is reached, and flagpole.yaml is large enough to exceed it. Past the cutoff,
+ * whole segment bodies come back with their children dropped, which the transform
+ * layer then mis-reads as a fully rolled-out (100%) segment. Parsing here has no
+ * item budget, so every feature is represented in full regardless of file size.
+ *
+ * The output mirrors the shape `vscode-json-languageservice` produces so the
+ * transform layer and every downstream consumer keep working unchanged:
+ *   - a map property becomes a symbol named after its key, whose `detail` is
+ *     derived from its *value* node (scalar text, or `'{}'`/`'[]'` for an empty
+ *     collection, or `undefined` for a non-empty one);
+ *   - a sequence item becomes a symbol named after its index; its `detail` is
+ *     derived the same way as a map value. The language server always leaves
+ *     sequence-item detail empty, but we populate it so condition value lists
+ *     (`- sentry`, `- charlie-test`, ...) can be read back without re-parsing.
+ *   - `range` spans the key start to the value's content end, `selectionRange`
+ *     covers just the key.
+ *
+ * flagpole.yaml aliases whole segments and condition-value lists to shared
+ * anchors (`- *_internal_orgs_segment`, `value: *_customer_single_tenants`). An
+ * alias is resolved to its anchor's node so the aliased segment's real rollout
+ * and conditions are seen; otherwise it would look like a bare 100% segment. The
+ * alias keeps its own source range so navigation still points at the usage site.
+ */
+export default function parseFlagpoleSymbols(document: vscode.TextDocument): vscode.DocumentSymbol[] {
+  const doc = parseDocument(document.getText());
+  if (!doc.contents) {
+    return [];
+  }
+  return collectChildren(document, doc, doc.contents as Node);
+}
+
+function collectChildren(document: vscode.TextDocument, doc: Document, node: Node): vscode.DocumentSymbol[] {
+  if (isMap(node)) {
+    return (node as YAMLMap).items.flatMap(pair => {
+      const key = pair.key;
+      // Ranges come from the alias usage site (`pair.value`); structure and
+      // children come from the resolved anchor, whose own range points at the
+      // definition elsewhere in the file.
+      const original = pair.value as Node | null;
+      const value = resolve(doc, original);
+      if (!isScalar(key) || !key.range) {
+        return [];
+      }
+      const keyRange = key.range;
+      const endOffset = original?.range ? original.range[1] : keyRange[1];
+      const range = new vscode.Range(document.positionAt(keyRange[0]), document.positionAt(endOffset));
+      const selectionRange = new vscode.Range(document.positionAt(keyRange[0]), document.positionAt(keyRange[1]));
+
+      const symbol = makeSymbol(String(key.value), getDetail(value), symbolKind(value), range, selectionRange);
+      symbol.children = value ? collectChildren(document, doc, value) : [];
+      return [symbol];
+    });
+  }
+
+  if (isSeq(node)) {
+    return (node as YAMLSeq).items.flatMap((item, index) => {
+      if (!isNode(item) || !item.range) {
+        return [];
+      }
+      const range = new vscode.Range(document.positionAt(item.range[0]), document.positionAt(item.range[1]));
+      const resolved = resolve(doc, item);
+      const symbol = makeSymbol(String(index), getDetail(resolved), symbolKind(resolved), range, range);
+      symbol.children = resolved ? collectChildren(document, doc, resolved) : [];
+      return [symbol];
+    });
+  }
+
+  return [];
+}
+
+/**
+ * Follows an alias to the node its anchor points at, so aliased segments and
+ * condition values expose their real structure. Non-alias nodes pass through.
+ */
+function resolve(doc: Document, node: Node | null): Node | null {
+  if (isAlias(node)) {
+    return node.resolve(doc) ?? null;
+  }
+  return node;
+}
+
+/**
+ * Mirrors `vscode-json-languageservice`'s `getDetail`: scalars stringify their
+ * value, an empty map/seq reports `'{}'`/`'[]'`, and a non-empty collection has
+ * no detail. The transform layer depends on the `'[]'`-vs-`undefined` split to
+ * tell an empty `conditions` list from one that has items.
+ */
+function getDetail(node: Node | null): string | undefined {
+  if (isScalar(node)) {
+    return String((node as Scalar).value);
+  }
+  if (isMap(node)) {
+    return (node as YAMLMap).items.length ? undefined : '{}';
+  }
+  if (isSeq(node)) {
+    return (node as YAMLSeq).items.length ? undefined : '[]';
+  }
+  return undefined;
+}
+
+function symbolKind(node: Node | null): vscode.SymbolKind {
+  if (isMap(node)) {
+    return vscode.SymbolKind.Module;
+  }
+  if (isSeq(node)) {
+    return vscode.SymbolKind.Array;
+  }
+  if (isScalar(node)) {
+    const value = (node as Scalar).value;
+    if (typeof value === 'boolean') {
+      return vscode.SymbolKind.Boolean;
+    }
+    if (typeof value === 'number') {
+      return vscode.SymbolKind.Number;
+    }
+    if (typeof value === 'string') {
+      return vscode.SymbolKind.String;
+    }
+  }
+  return vscode.SymbolKind.Variable;
+}
+
+function makeSymbol(
+  name: string,
+  detail: string | undefined,
+  kind: vscode.SymbolKind,
+  range: vscode.Range,
+  selectionRange: vscode.Range,
+): vscode.DocumentSymbol {
+  // `detail` is typed `string`, but the language server (and the rest of this
+  // extension) rely on it being `undefined` for non-empty collections and
+  // sequence items; the cast preserves that at runtime.
+  return new vscode.DocumentSymbol(name, detail as string, kind, range, selectionRange);
+}

--- a/src/transform/transformers.test.ts
+++ b/src/transform/transformers.test.ts
@@ -86,6 +86,21 @@ suite('transformers', () => {
       const result = symbolToLogicalCondition(uri, parent, conditionSymbol);
       assert.deepStrictEqual(result.value, ['...']);
     });
+
+    test('reads a list value from its child items', () => {
+      const parent = makeConditions([]);
+      const value = makeSymbol('value', '', [
+        makeSymbol('0', 'sentry'),
+        makeSymbol('1', 'charlie-test'),
+      ]);
+      const conditionSymbol = makeSymbol('0', '', [
+        makeSymbol('operator', 'in'),
+        makeSymbol('property', 'organization_slug'),
+        value,
+      ]);
+      const result = symbolToLogicalCondition(uri, parent, conditionSymbol);
+      assert.deepStrictEqual(result.value, ['sentry', 'charlie-test']);
+    });
   });
 
   suite('symbolToLogicalSegment', () => {

--- a/src/transform/transformers.ts
+++ b/src/transform/transformers.ts
@@ -161,9 +161,19 @@ export function symbolToLogicalCondition(
     uri,
     operator: operator?.detail ?? '',
     property: property?.detail ?? '',
-    value: value?.detail || ['...'],
-    // TODO: we could go and read all the values in the array, but it'll be a bit
-    // slower, and there are often a lot of values that makes things scroll a lot
-    // value: (value?.detail || value?.children.map(child => ...)) ?? '',
+    value: conditionValue(value),
   };
+}
+
+/**
+ * A condition's `value` is either a scalar (its `detail`) or a list, whose items
+ * arrive as child symbols each carrying their scalar `detail`. An empty or
+ * missing value falls back to `['...']` so the UI still renders a placeholder.
+ */
+function conditionValue(value: vscode.DocumentSymbol | undefined): string | string[] {
+  if (value?.detail) {
+    return value.detail;
+  }
+  const items = value?.children.map(child => child.detail).filter(detail => detail !== undefined) ?? [];
+  return items.length ? items : ['...'];
 }

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -202,25 +202,6 @@ export function startManualSpan(operationName: string, op: string = 'operation')
 }
 
 /**
- * Capture a message to Sentry with optional context.
- */
-export function captureMessage(
-  message: string,
-  level: SeverityLevel = 'info',
-  context?: Record<string, any>
-): void {
-  if (!sentryScope) {
-    return;
-  }
-
-  if (context) {
-    sentryScope.setContext('additional', context);
-  }
-  
-  sentryScope.captureMessage(message, level);
-}
-
-/**
  * Capture an exception to Sentry with optional context.
  */
 export function captureException(error: Error, context?: Record<string, any>): void {


### PR DESCRIPTION
Features past the YAML language server's `maxItemsComputed` cutoff had their segment bodies truncated to empty children, which the transform layer mis-read as a fully rolled-out (100%) segment. In the large flagpole.yaml this affected the majority of features — every flag below the cutoff showed 100% regardless of its real rollout.

Replace the symbol source in OutlineStore: instead of `vscode.executeDocumentSymbolProvider` (whole-file, truncated), parse the document text ourselves with the `yaml` library, which has no item budget. A new parseFlagpoleSymbols builds a DocumentSymbol tree mirroring the language server's shape, so the transform layer, providers, and tree views are unchanged.

The parser also resolves YAML aliases (`- *segment`, `value: *anchor`) to their anchor, fixing a related class of misreport where aliased segments looked like bare 100% segments, and reads real condition value lists instead of a placeholder.

Remove the now-inert async-symbol verification pass and the dead Outline.symbols field, since parsing the exact buffer text synchronously makes stale symbols impossible. Bundle yaml's browser build (the extension runs in a web worker) and raise maxItemsComputed for VS Code's native outline.